### PR TITLE
Ребаланс рецептов сортировки из KaoExtended

### DIFF
--- a/mods/zzzparanoidal_1.0.1/prototypes/recipefixes.lua
+++ b/mods/zzzparanoidal_1.0.1/prototypes/recipefixes.lua
@@ -17,6 +17,17 @@ data.raw.recipe["bob-nickel-plate"].hidden = false
 data.raw.recipe["invar-alloy"].hidden = false
 data.raw.recipe["brass-alloy"].hidden = false
 
+--ребаланс сортировки из KaoExtended
+data.raw.recipe["angelsore-crushed-manganese-processing"].results[1].amount=4
+data.raw.recipe["angelsore-pure-chrome-processing"].results[1].amount=3
+data.raw.recipe["angelsore-pure-platinum-processing"].results[1].amount=2
+data.raw.recipe["angelsore-crushed-manganese-processing"].category = "ore-sorting-2"
+data.raw.recipe["angelsore-pure-chrome-processing"].category = "ore-sorting-3"
+data.raw.recipe["angelsore-pure-platinum-processing"].category = "ore-sorting-3"
+angelsmods.functions.allow_productivity("angelsore-crushed-manganese-processing")
+angelsmods.functions.allow_productivity("angelsore-pure-chrome-processing")
+angelsmods.functions.allow_productivity("angelsore-pure-platinum-processing")
+
 --правильно добавлять ингриды в рецепт
 --[[
   if data.raw.recipe["advanced-logistic-science-pack"] then


### PR DESCRIPTION
Приводит рецепты сортировки с катализатором из KaoExtended в (примерное) соответствие с другими подобными рецептами, чтобы был хоть какой-то смысл их использовать вместо обычной сортировки.