### PR TITLE
Возвращает cement processing 2 на красные+зелёные банки

### DIFF
--- a/mods/zzzparanoidal/final-fixes/technologies.lua
+++ b/mods/zzzparanoidal/final-fixes/technologies.lua
@@ -132,6 +132,12 @@ paralib.bobmods.lib.tech.add_recipe_unlock("angels-ore-crushing", "glass-from-or
 paralib.bobmods.lib.tech.remove_prerequisite("angels-solid-cement", "concrete") --бетон
 paralib.bobmods.lib.tech.remove_prerequisite("angels-stone-smelting-2", "concrete") --бетон
 paralib.bobmods.lib.tech.remove_prerequisite("angels-plastic-1", "plastics") --пластик
+--cement processing 2 без синих банок (как в 1.1)
+paralib.bobmods.lib.tech.remove_prerequisite("angels-stone-smelting-2", "chemical-science-pack")
+paralib.bobmods.lib.tech.set_science_packs("angels-stone-smelting-2", {
+	{ "automation-science-pack", 1 },
+	{ "logistic-science-pack", 1 },
+})
 
 -- добавляем зависимости в техологии для последовательности развития
 paralib.bobmods.lib.tech.add_prerequisite("concrete", "angels-stone-smelting-2") --бетон


### PR DESCRIPTION
## Что и зачем

В 1.1 технология `angels-stone-smelting-2` (Цементная обработка 2) исследовалась за красные+зелёные пакеты науки и не зависела от `chemical-science-pack`. Цепочка `cement processing 2` → `concrete` → `railway` (которую `zzzparanoidal` собирает в `final-fixes/technologies.lua`) проходила за две колбы.

При портировании `angelssmelting` на 2.0 авторы мода добавили `chemical-science-pack` в `prerequisites` и в `unit.ingredients` у `angels-stone-smelting-2`:

```lua
-- angelssmelting/prototypes/technology/smelting-stone.lua
name = "angels-stone-smelting-2",
prerequisites = {
  "chemical-science-pack",          -- новое в 2.0
  "angels-powder-metallurgy-2",
  "angels-silicon-smelting-1",
  "angels-stone-smelting-1",
  "concrete",
  "angels-resins",
},
unit = {
  ingredients = {
    { "automation-science-pack", 1 },
    { "logistic-science-pack", 1 },
    { "chemical-science-pack", 1 },  -- новое в 2.0
  },
}
```

Из-за этого вся цепочка до `railway` сейчас тянет синюю науку, чего в 1.1 не было.

## Правка

В `mods/zzzparanoidal/final-fixes/technologies.lua` рядом с другими цементными фиксами:
- `remove_prerequisite("angels-stone-smelting-2", "chemical-science-pack")` — убирает новый пререквизит из 2.0
- `set_science_packs("angels-stone-smelting-2", { red, green })` — возвращает стоимость к R+G как в 1.1

Стилистически правка идёт в духе соседних фиксов `angels-stone-smelting-4` (cement 4) и `OilBurning-4/5`. Без `if data.raw.technology[...]`, потому что `angels-stone-smelting-2` определена в `angelssmelting`, который в `info.json` `zzzparanoidal` обязательная зависимость, а значит существует всегда (в отличие от `angels-stone-smelting-4` из опционального `extendedangels`).

Существующие связи `add_prerequisite("concrete", "angels-stone-smelting-2")` (строка 137 после правки → 143) и `add_prerequisite("railway", "concrete")` (около строки 312) уже на месте, цепочка `cement 2 → concrete → railway` сохраняется.

## Проверка

Проверено локально на текущей сборке: после правки `cement processing 2` отображается с двумя пакетами науки (R+G), `railway` доступна без исследования синей науки — соответствует поведению 1.1.
Closes #197
