### PR TITLE
Удаляет избыточную ветку alloy-mixer (МК1-МК4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ bin
 obj
 temp
 .idea
+**/.DS_Store
 mods/mod-settings.dat
 mods/mod-list.json
 mods/*.zip

--- a/mods/zzzparanoidal/data-final-fixes.lua
+++ b/mods/zzzparanoidal/data-final-fixes.lua
@@ -59,6 +59,7 @@ require("tweaks.custom.selections")
 
 require("removals.bio-modules")
 require("removals.fishes")
+require("removals.alloy-mixer")
 
 require("graphics.train.train_reskin") -- рескин поездов
 -------------------------------------------------------------------------------------------------

--- a/mods/zzzparanoidal/removals/alloy-mixer.lua
+++ b/mods/zzzparanoidal/removals/alloy-mixer.lua
@@ -1,0 +1,28 @@
+require("__zzzparanoidal__.paralib")
+-- Удаление мёртвой ветки alloy-mixer (МК1-МК4) из angelsextended-remelting-fixed.
+-- В 1.1 эта линия была единственным способом получить сплавы (бронза/латунь/инвар/гунметал/кобальт-сталь/нитинол).
+-- В 2.0 angelssmelting сам делает все эти сплавы (категории angels-induction-smelting-2/3/4)
+-- через обычные angels-induction-furnace, поэтому отдельная ветка alloy-mixer стала избыточной.
+-- Сохраняем рецепты molten-X-remelting (категория angels-induction-smelting) — они
+-- работают в induction-furnace и нужны для переплавки bob-сплавов в жидкий вид.
+
+-- Прячем 4 техи "Продвинутое смешивание металлов 1-4"
+for i = 1, 4 do
+	paralib.bobmods.lib.tech.hide("remelting-alloy-mixer-" .. i)
+end
+
+-- Прячем 4 здания "Смешиватель Металлов МК1-МК4" (рецепт + предмет)
+local mixer_names = { "alloy-mixer", "alloy-mixer-2", "alloy-mixer-3", "alloy-mixer-4" }
+for _, name in ipairs(mixer_names) do
+	paralib.bobmods.lib.recipe.hide(name)
+	if data.raw.item[name] then
+		data.raw.item[name].hidden = true
+	end
+end
+
+-- Прячем все рецепты категории molten-alloy-mixing (рецепты этих зданий)
+for name, recipe in pairs(data.raw.recipe) do
+	if recipe.category == "molten-alloy-mixing" then
+		paralib.bobmods.lib.recipe.hide(name)
+	end
+end


### PR DESCRIPTION
Closes #196

## Проблема

В дереве технологий есть линия `Продвинутое смешивание металлов 1-4` (`remelting-alloy-mixer-1..4`), которая разблокирует здания «Смешиватель Металлов МК1-МК4» (`alloy-mixer/-2/-3/-4`). Игрок видит её как тупиковую ветку: здания крафтятся, но рецепты в них пустые/неочевидные, а функциональность дублирует обычную линию `angels-induction-furnace`.

См. скриншоты в issue #196 — два визуально похожих смешивателя в крафт-меню, в одном (`Induction furnace 1`) куча сплавов работает, в другом (`Смешиватель Металлов МК1`) пусто.

## Корень проблемы

Сравнил состояние мода `angelssmelting` между 1.1 и 2.0:

**1.1 — `angelssmelting/prototypes/recipes/` имел только 2 рецепта сплавов:**
- `smelting-alloy-solder.lua`
- `smelting-alloy-steel.lua`

Бронзу, латунь, инвар, гунметал, кобальт-сталь и нитинол **можно было получить только** через `angelsextended-remelting-fixed` — линия `alloy-mixer` была единственным путём к этим сплавам и имела смысл.

**2.0 — `angelssmelting` поглотил все эти сплавы:**
- `smelting-alloy-brass.lua` — новое
- `smelting-alloy-bronze.lua` — новое
- `smelting-alloy-cobalt-steel.lua` — новое
- `smelting-alloy-gunmetal.lua` — новое
- `smelting-alloy-invar.lua` — новое
- `smelting-alloy-nitinol.lua` — новое

Все они получили категории `angels-induction-smelting-2/3/4` и работают в обычной `angels-induction-furnace-2/3/4`, которая открывается через `angels-metallurgy-2/3/4`.

В итоге `alloy-mixer` МК1-МК4 в 2.0 стала **мёртвой параллельной веткой**, которую авторы `angelsextended-remelting-fixed` не убрали при портировании.

## Что важно сохранить

В `angelsextended-remelting-fixed` есть **два разных типа рецептов** в одних и тех же файлах:

| | `*-alloy-mixing-N` | `*-remelting` |
|---|---|---|
| Что делает | жидкий металл + жидкий металл → жидкий сплав | твёрдый bob-сплав → жидкий сплав |
| Категория | `molten-alloy-mixing` | `angels-induction-smelting` |
| Где работает | `alloy-mixer` МК1-МК4 (мёртвая ветка) | `angels-induction-furnace` (рабочая ветка) |
| В 2.0 | дубль с `angels-X-smelting-N` через `angelssmelting` | реальная функциональность для рециклинга bob-сплавов |

PR убирает только `*-alloy-mixing-N` ветку, оставляя `*-remelting` рабочей.

## Решение

Новый файл `mods/zzzparanoidal/removals/alloy-mixer.lua` (в стиле существующих `removals/fishes.lua`, `removals/bio-modules.lua`):

```lua
require("__zzzparanoidal__.paralib")
-- Прячем 4 техи "Продвинутое смешивание металлов 1-4"
for i = 1, 4 do
    paralib.bobmods.lib.tech.hide("remelting-alloy-mixer-" .. i)
end

-- Прячем 4 здания "Смешиватель Металлов МК1-МК4"
local mixer_names = { "alloy-mixer", "alloy-mixer-2", "alloy-mixer-3", "alloy-mixer-4" }
for _, name in ipairs(mixer_names) do
    paralib.bobmods.lib.recipe.hide(name)
    if data.raw.item[name] then
        data.raw.item[name].hidden = true
    end
end

-- Прячем все рецепты категории molten-alloy-mixing
for name, recipe in pairs(data.raw.recipe) do
    if recipe.category == "molten-alloy-mixing" then
        paralib.bobmods.lib.recipe.hide(name)
    end
end
```

Подключение в `data-final-fixes.lua` рядом с другими removals:

```lua
require("removals.bio-modules")
require("removals.fishes")
require("removals.alloy-mixer")
```

Используются стандартные `paralib`-обёртки (`tech.hide`, `recipe.hide`), которые уже применяются в других файлах `removals/`. Динамический фильтр по `recipe.category == "molten-alloy-mixing"` подхватывает все 17 существующих рецептов и автоматически защитит от появления новых рецептов в этой категории.

## Бонус-коммит

Дополнительно: `**/.DS_Store` в `.gitignore` — чтобы macOS-файлы не попадали в коммиты. Никаких отслеживаемых `.DS_Store` сейчас в репе нет, так что `git rm` не требуется.

## Проверка

Локально протестировано на 2.0.76:
- В дереве технологий ветка `Продвинутое смешивание металлов 1-4` пропала.
- В крафт-меню зданий «Смешиватель Металлов МК1-МК4» нет.
- `Induction furnace 1+` продолжает крафтить сплавы (бронза/латунь/инвар/...) как обычно.
- Рецепты `molten-X-remelting` (рециклинг bob-сплавов в индукционке) работают.