### PR TITLE
Скрывает мёртвую теху medium-electric-pole от aai-industry

### DIFF
--- a/mods/zzzparanoidal/data-final-fixes.lua
+++ b/mods/zzzparanoidal/data-final-fixes.lua
@@ -59,6 +59,7 @@ require("tweaks.custom.selections")
 
 require("removals.bio-modules")
 require("removals.fishes")
+require("removals.aai-medium-electric-pole")
 
 require("graphics.train.train_reskin") -- рескин поездов
 -------------------------------------------------------------------------------------------------

--- a/mods/zzzparanoidal/removals/aai-medium-electric-pole.lua
+++ b/mods/zzzparanoidal/removals/aai-medium-electric-pole.lua
@@ -1,0 +1,32 @@
+require("__zzzparanoidal__.paralib")
+-- Скрываем пустую теху "Средняя опора ЛЭП" (medium-electric-pole) от aai-industry.
+-- Теха определена в aai-industry/prototypes/phase-1/technology/technology.lua без effects,
+-- а её наполнение (tech_lock_recipes("medium-electric-pole", {"medium-electric-pole"}) и
+-- перенос рецепта с vanilla-теха electric-energy-distribution-1) лежит в
+-- aai-industry/prototypes/phase-2/technology/technology.lua, который НИГДЕ не require()-ится.
+-- При портировании на 2.0 авторы убрали require("phase-2/...") из data*.lua, но саму теху
+-- из phase-1 оставили. В итоге теха пустая, рецепт medium-electric-pole штатно открывается
+-- через electric-energy-distribution-1, а игрок видит дубль с пустым "Результатом".
+--
+-- Условный фикс — три кейса для hide:
+--   1) tech.effects == nil — исходный баг без research_evolution_factor;
+--   2) tech.effects == {} — пустой массив на тот же случай;
+--   3) tech.effects == [{type="nothing"}] — research_evolution_factor добавляет
+--      такой декоративный модификатор в каждую не-hidden теху для своей механики
+--      эволюции (рендерится как красный "+"). К моменту нашей проверки у пустой
+--      теха ровно один такой "nothing".
+-- Любой реальный эффект (например unlock-recipe) — оставляем теху видимой:
+-- если/когда aai-industry починит загрузку phase-2 и эффект появится, hide
+-- перестанет срабатывать без ручных правок.
+
+local tech = data.raw.technology["medium-electric-pole"]
+if
+	tech
+	and (
+		not tech.effects
+		or #tech.effects == 0
+		or (#tech.effects == 1 and tech.effects[1].type == "nothing")
+	)
+then
+	paralib.bobmods.lib.tech.hide("medium-electric-pole")
+end


### PR DESCRIPTION
Closes #195

## Что видит игрок

В дереве технологий отображается тех «Средняя опора ЛЭП» (1R+1G, x75) с **пустым «Результатом»** — никаких рецептов не открывает. Это создаёт путаницу: рядом стоит настоящая тех «Электроснабжение 1» (`electric-energy-distribution-1`), которая и так штатно открывает рецепт `medium-electric-pole`.

См. скриншоты в issue #195 — на тултипе пустой `+` вместо иконки здания, при этом тех визуально неотличима от реальной за счёт скопированной иконки `electric-energy-distribution-1`.

## Корень проблемы

Баг в самом `aai-industry`:

1. **`prototypes/phase-1/technology/technology.lua:329`** — определена тех `medium-electric-pole` без `effects`:

   ```lua
   {
       type = "technology",
       name = "medium-electric-pole",
       icon = data.raw.technology["electric-energy-distribution-1"].icon,
       icon_size = 256,
       order = "a",
       prerequisites = {"steel-processing", "electricity", "logistic-science-pack"},
       unit = { count = 75, ingredients = {{"automation-science-pack", 1}, {"logistic-science-pack", 1}}, time = 30 },
   },
   ```

2. **`prototypes/phase-2/technology/technology.lua:52-54`** — её наполнение, переносящее рецепт `medium-electric-pole` с vanilla `electric-energy-distribution-1` на эту теху:

   ```lua
   util.tech_lock_recipes("medium-electric-pole", {"medium-electric-pole"})
   util.tech_remove_prerequisites("electric-energy-distribution-1", {"logistic-science-pack", "steel-processing"})
   util.tech_add_prerequisites("electric-energy-distribution-1", {"concrete", "medium-electric-pole"})
   ```

3. **Директория `phase-2` нигде не `require()`-ится.** В `aai-industry/data.lua`, `data-updates.lua`, `data-final-fixes.lua` подключаются `phase-1` и `phase-3`, но не `phase-2`. Видимо, при портировании на Factorio 2.0 авторы аккуратно перевели phase-1/3 и забыли про phase-2.

В итоге:
- Тех `medium-electric-pole` существует, но без эффектов
- Рецепт `medium-electric-pole` остался на `electric-energy-distribution-1` (vanilla)
- Игрок видит дубль с пустым результатом

## Решение

Новый файл `mods/zzzparanoidal/removals/aai-medium-electric-pole.lua` рядом с другими `removals/`:

```lua
require("__zzzparanoidal__.paralib")

local tech = data.raw.technology["medium-electric-pole"]
if tech and tech.effects and #tech.effects == 1 and tech.effects[1].type == "nothing" then
    paralib.bobmods.lib.tech.hide("medium-electric-pole")
end
```

Условие учитывает один важный нюанс: **`research_evolution_factor`** в своём `data-final-fixes.lua` добавляет `{type = "nothing", effect_description = ...}` в каждую не-hidden теху как декоративный модификатор для своей механики эволюции (это и есть тот самый красный `+` иконка в Результате). REF загружается раньше zzzparanoidal по алфавиту, поэтому к моменту нашей проверки у пустой теха ровно один такой `nothing`. Проверка `#tech.effects == 1` + `tech.effects[1].type == "nothing"` корректно отлавливает пустую теху, не зацепляя нормальные техи.

Подключение в `data-final-fixes.lua` рядом с другими removals:

```lua
require("removals.bio-modules")
require("removals.fishes")
require("removals.aai-medium-electric-pole")
```

## Что будет в будущем

Фикс **самовыключающийся**:

| Сценарий | Поведение фикса |
|----------|----------|
| Сейчас (баг в aai-industry) | теха пустая (только REF-`nothing`), `effects` = 1 → прячем |
| aai-industry чинит phase-2 | теха получает `unlock-recipe`, `effects` = 2 (unlock + REF-nothing) → условие ложно, не прячем |
| `research_evolution_factor` отключают | пустая теха имеет `effects` = 0 → условие ложно, не прячем (но игрок и без REF тогда увидит пустую теху — потребуется отдельный фикс/обновление этой проверки) |
| `aai-industry` убирает теху совсем | `data.raw.technology[...]` = nil → no-op |

Главное — когда (и если) авторы `aai-industry` восстановят `require("phase-2/...")`, наш фикс **сам перестанет срабатывать без ручных правок**, и тех заработает как было задумано.

## Проверка

Локально протестировано на 2.0.76: тех «Средняя опора ЛЭП» больше не отображается в дереве, рецепт `medium-electric-pole` штатно открывается через «Электроснабжение 1».
