### PR TITLE
Убирает бесполезный bob-burner-lab из ингредиентов рецепта lab

### DIFF
--- a/mods/zzzparanoidal/final-fixes/technologies.lua
+++ b/mods/zzzparanoidal/final-fixes/technologies.lua
@@ -653,6 +653,10 @@ paralib.bobmods.lib.tech.hide("bob-burner-lab")
 paralib.bobmods.lib.tech.remove_prerequisite("automation-science-pack", "bob-burner-lab")
 -- fix research trigger from bob-burner-lab -> burner-lab
 data.raw.technology["automation-science-pack"].research_trigger.item = "burner-lab"
+-- bobtech (recipe-updates.lua:98) добавляет bob-burner-lab в ингредиенты рецепта lab,
+-- но мы скрыли его теху → крафт невозможен. В рецепте lab уже есть burner-lab от
+-- aai-industry — он и остаётся каноном. Убираем дубль.
+paralib.bobmods.lib.recipe.remove_ingredient("lab", "bob-burner-lab")
 
 -- add electric-motor recipe unlock to electricity tech
 paralib.bobmods.lib.tech.add_recipe_unlock("electricity", "electric-motor")


### PR DESCRIPTION
Closes #193

## Что видит игрок

В рецепте «Электрическая лаборатория» (`lab`) отображаются **две** «Твердотопливная лаборатория»:

- 0/5 Малый электромотор
- **1× Твердотопливная лаборатория**
- **1× Твердотопливная лаборатория**
- 5× Glass
- 5× Базовая печатная плата

При этом, как описывает [issue #193](https://github.com/FactorioParanoidal/ParanoidalModpack/issues/193), «только одну можно создать» — рецепт лаборатории становится невыполнимым, потому что игрок никогда не сможет добыть второй ингредиент.

## Корень проблемы

Два разных предмета с одинаковым отображаемым именем оказываются в ингредиентах одного рецепта:

| Внутреннее имя | Откуда | RU-локаль | EN-локаль |
|---|---|---|---|
| `burner-lab` | aai-industry | «Твердотопливная лаборатория» | Burner lab |
| `bob-burner-lab` | bobtech | «Твердотопливная лаборатория» | Burner lab |

Цепочка как они оба попадают в `lab`:

1. `aai-industry/prototypes/phase-1/recipe/base-recipe-changes.lua:357-365` выставляет ингредиенты `lab`: 5 electronic-circuit, 5 electric-motor, 5 glass, **1 `burner-lab`** (свой, aai-industry).

2. `bobtech/prototypes/recipe/recipe-updates.lua:97-99` при включённой настройке `bobmods-burnerphase` **добавляет** в тот же рецепт ещё **1 `bob-burner-lab`** (свой, bobtech):

   ```lua
   if settings.startup["bobmods-burnerphase"].value == true then
       bobmods.lib.recipe.add_new_ingredient("lab", { type = "item", name = "bob-burner-lab", amount = 1 })
   end
   ```

3. `zzzparanoidal/final-fixes/technologies.lua:651-655` уже сделал работу по «закрытию» `bob-burner-lab`:

   ```lua
   -- Hide starting bob-burner-lab tech
   paralib.bobmods.lib.tech.hide("bob-burner-lab")
   paralib.bobmods.lib.tech.remove_prerequisite("automation-science-pack", "bob-burner-lab")
   -- fix research trigger from bob-burner-lab -> burner-lab
   data.raw.technology["automation-science-pack"].research_trigger.item = "burner-lab"
   ```

   То есть paranoidal принципиально выбрал `burner-lab` (aai-industry) каноном и спрятал `bob-burner-lab` тех + перевёл research_trigger. Но **`bob-burner-lab` из ингредиентов `lab` остался** — поэтому игрок видит дубль с непонятным невозможным крафтом.

## Решение

Дополняем существующий блок одной строкой:

```lua
paralib.bobmods.lib.recipe.remove_ingredient("lab", "bob-burner-lab")
```

Завершает работу, которую paranoidal начал в этом же блоке. После фикса в рецепте `lab` остаётся только `burner-lab` (aai-industry), который игрок может скрафтить штатно.

## Безопасность фикса

- При выключенной настройке `bobmods-burnerphase` bobtech не добавляет `bob-burner-lab` в `lab` → `remove_ingredient` тихо находит ничего и завершается. Под капотом `bobmods.lib.recipe.remove_ingredient` (`boblibrary/recipe-functions.lua`) делает простой `bobmods.lib.item.remove(ingredients, item)`, который безопасен для отсутствующих элементов.
- Пока paranoidal явно прячет теху `bob-burner-lab` в этом же блоке, фикс корректен и логически консистентен с уже существующей политикой выбора `burner-lab` каноном.
- Если в будущем paranoidal решит наоборот — оставлять `bob-burner-lab` каноном, эту строку можно убрать одновременно с remove_prerequisite/research_trigger выше.

## Проверка

Локально протестировано на 2.0.76: в рецепте «Электрическая лаборатория» теперь отображается одна «Твердотопливная лаборатория» (`burner-lab`), которую игрок может крафтить.