### PR TITLE
Перестаёт принудительно включать bob-lead-plate-2 на старте

### DIFF
--- a/mods/zzzparanoidal/data-final-fixes.lua
+++ b/mods/zzzparanoidal/data-final-fixes.lua
@@ -151,20 +151,5 @@ if data.raw.recipe["angels-ore6-smelting"] then
     log("[NEXUS-UA] angels-ore6-smelting: DISABLED + HIDDEN (replaced by bob-tin-plate)")
 end
 
--- Залишити bob-lead-plate-2 доступним (хімічна піч)
-if data.raw.recipe["bob-lead-plate-2"] then
-    local r = data.raw.recipe["bob-lead-plate-2"]
-    r.enabled = true
-    r.hidden = false
-    r.localised_name = nil
-    r.icons = {
-        { icon = "__bobplates__/graphics/icons/plate/lead-plate.png", icon_size = 32 }
-    }
-    r.icon = nil
-    r.icon_size = 32
-    log("[NEXUS-UA] bob-lead-plate-2 set icon path: __bobplates__/graphics/icons/plate/lead-plate.png")
-end
-
-
 --должно быть последним. После всех рецептов.
 require("tweaks.custom.flowfix")


### PR DESCRIPTION
Closes #191

## Что видит игрок

С самого старта игры в крафт-меню доступен рецепт **Lead plate** (`bob-lead-plate-2`, chemical furnace вариант) — что не должно быть доступно. Скриншот в issue #191.

## Корень проблемы

Блок в `mods/zzzparanoidal/data-final-fixes.lua:154-166` принудительно включает рецепт на старте:

```lua
-- Залишити bob-lead-plate-2 доступним (хімічна піч)
if data.raw.recipe["bob-lead-plate-2"] then
    local r = data.raw.recipe["bob-lead-plate-2"]
    r.enabled = true        -- ← рецепт открыт сразу
    r.hidden = false        -- ← и виден сразу
    r.localised_name = nil
    r.icons = { { icon = "__bobplates__/graphics/icons/plate/lead-plate.png", icon_size = 32 } }
    r.icon = nil
    r.icon_size = 32
    log("[NEXUS-UA] bob-lead-plate-2 set icon path: ...")
end
```

## Что вообще происходит с `bob-lead-plate-2` в paranoidal

В bob/angels интеграции у этого рецепта непростая судьба:

1. **bobplates** (`prototypes/recipe/plates-recipe.lua:45-58`) определяет `bob-lead-plate-2` с `enabled = false` и подвешивает его к теху `bob-lead-processing` (`technology-updates.lua:61`).

2. **angelssmelting** при ingot-mode полностью гасит и рецепт, и теху:
   - `prototypes/override/smelting-override-lead.lua:79`: `OV.disable_recipe({"bob-lead-plate", "bob-lead-plate-2"})` — ставит `enabled = false` и скрывает рецепт.
   - `prototypes/override/smelting-override-lead.lua:36`: `OV.global_replace_technology("bob-lead-processing", "angels-lead-smelting-1")` — `bob-lead-processing` тех вообще исчезает, заменяется на angels.

   То есть вся ветка `bob-lead-plate-2` через chemical furnace **намеренно убрана** angels-смелтингом — chemical furnace путь дублирует ангеловское литьё, и paranoidal стороной angels опирается.

3. **NEXUS-UA блок** в `data-final-fixes.lua` (коммит [`9c2503acb`](https://github.com/FactorioParanoidal/ParanoidalModpack/commit/9c2503acb)) пытается **вернуть** `bob-lead-plate-2` после angels-disable. Комментарий «Залишити bob-lead-plate-2 доступним» как раз про это. Но реализовано неправильно — `enabled = true` делает рецепт доступным с **самого старта** (минуя любую теху), вместо того чтобы привязать к какой-то теху.

## Что даёт удаление блока

После удаления `bob-lead-plate-2` остаётся отключённым через angels (`OV.disable_recipe`) — рецепт пропадает из крафт-меню совсем. Это не критично, потому что **альтернативные пути получения `bob-lead-plate` уже существуют** в paranoidal:

| Путь | Когда доступен | Откуда |
|---|---|---|
| `bob-lead-plate` (smelting, 7×`angels-ore5-crushed` → 4 плиты + slag) | со старта | NEXUS-UA блок выше в `data-final-fixes.lua:78-107` |
| `angels-roll-lead` (литьё через angels-lead-smelting tech-tree) | поздно, через `angels-lead-smelting-1/2/3` | `angelssmelting` штатно |

Третий вариант через chemical furnace в paranoidal **избыточен** и был и так задизаблен angels — поэтому возвращать его не нужно.

## Почему удаляем весь блок целиком, а не только `enabled/hidden`

Каждая строка либо вредит, либо не делает ничего полезного:

| Строка | Что делает | Что будет без неё |
|---|---|---|
| `r.enabled = true` | даёт рецепт на старте (БАГ) | `enabled = false` от angels' `OV.disable_recipe` — рецепт скрыт целиком, но это ок (см. альтернативы выше) |
| `r.hidden = false` | принудительно показывает | `hidden = true` от angels — невидим, ок |
| `r.localised_name = nil` | сбрасывает кастомное имя | у рецепта в bobplates **нет** `localised_name` — no-op |
| `r.icons = { ..., icon_size = 32 }` | задаёт иконку с размером 32 | unused, рецепт скрыт |
| `r.icon = nil` | сбрасывает | no-op |
| `r.icon_size = 32` | меняет размер | no-op |

Бонус: `r.icons.icon = lead-plate.png + icon_size = 32` — это та же PNG что у item (`bob-lead-plate`), но с неправильным размером (PNG 64x64 рендерится как 32x32). Если бы рецепт когда-то вернули в видимое состояние, иконка отображалась бы битой.

## Что НЕ трогаем

Остальные `[NEXUS-UA]` блоки в `data-final-fixes.lua`:
- замена `bob-lead-ore` → `angels-ore5-crushed` в `bob-lead-plate` (с slag-выходом) — early-game путь Lead plate
- аналог для `bob-tin-plate` через `angels-ore6-crushed`
- отключение `angels-ore5-smelting` и `angels-ore6-smelting` (как замещённые более выгодными crushed-вариантами)

— это интенциональная angels-bob интеграция Rubyte/Bobmonium → плита через crushed-руду. Не баг, оставляем как есть.

## Проверка

Локально на 2.0.76: после удаления блока рецепт `bob-lead-plate-2` исчезает из доступных рецептов. Получение Lead plate возможно через:
- ранний `bob-lead-plate` (smelting, через `angels-ore5-crushed`) — со старта.
- штатный `angels-roll-lead` (литьё) — после исследования angels-lead-smelting.