### PR TITLE
Поднимает ingredient_count для AM1 и electronics-machine-1 (fix #190)

### DIFF
--- a/mods/zzzparanoidal/tweaks/entity/assemblers.lua
+++ b/mods/zzzparanoidal/tweaks/entity/assemblers.lua
@@ -1,6 +1,4 @@
 require("__zzzparanoidal__.paralib")
--- подкрутка чтобы сборщик1 мог собирать сам себя
-data.raw["assembling-machine"]["assembling-machine-1"].ingredient_count = 5
 -- Добавление нужных для крафта конденсаторов категорий в сборочники
 local function AssemblerTweak(name)
     if(data.raw["assembling-machine"][name]) then
@@ -17,15 +15,15 @@ AssemblerTweak("bob-assembling-machine-4")
 AssemblerTweak("bob-assembling-machine-5")
 AssemblerTweak("bob-assembling-machine-6")
 
--- from KaoExtended
-data.raw["assembling-machine"]["assembling-machine-1"].ingredient_count = 4
+-- from KaoExtended (issue #190: было 4 — рецепты зданий 2.0 требуют 5-6 ингредиентов, AM2 не крафтился в AM1)
+data.raw["assembling-machine"]["assembling-machine-1"].ingredient_count = 6
 data.raw["assembling-machine"]["assembling-machine-2"].ingredient_count = 7
 data.raw["assembling-machine"]["assembling-machine-3"].ingredient_count = 9
 data.raw["assembling-machine"]["bob-assembling-machine-4"].ingredient_count = 12
 data.raw["assembling-machine"]["bob-assembling-machine-5"].ingredient_count = 15
 data.raw["assembling-machine"]["bob-assembling-machine-6"].ingredient_count = 20
 
-data.raw["assembling-machine"]["bob-electronics-machine-1"].ingredient_count = 5
+data.raw["assembling-machine"]["bob-electronics-machine-1"].ingredient_count = 6 -- issue #190: было 5, advanced-circuit и модули требуют 6
 data.raw["assembling-machine"]["bob-electronics-machine-2"].ingredient_count = 10
 data.raw["assembling-machine"]["bob-electronics-machine-3"].ingredient_count = 16
 


### PR DESCRIPTION
## Что сделано

`assembling-machine-1`: `ingredient_count` 4 → **6**.
`bob-electronics-machine-1`: `ingredient_count` 5 → **6**.

В `tweaks/entity/assemblers.lua` стояли две конфликтующие строки для AM1: сверху `= 5` (с комментарием "чтобы сборщик1 мог собирать сам себя"), ниже `= 4` ("from KaoExtended") — второе перезаписывало первое. Это латентный конфликт двух 1.1-модов, скопированный as-is при синхронизации с VOLBAX2 в коммите 9c2503acb. Дубликат `= 5` убран.

## Почему 6

В версии 2.0 рецепты зданий из bob/angels/angelsindustries раздулись до **5–6 ингредиентов**. При `ingredient_count = 4` многие здания вообще нельзя было крафтить в AM1, при `= 5` — в AM1 не помещался `assembling-machine-2` (6 ингредиентов) и ряд других. Аналогично `advanced-circuit` (6 ингредиентов) не крафтился в `bob-electronics-machine-1` при лимите 5.

`6` — минимум, который закрывает все случаи из issue #190 (HydroPlant 1, Electrolyser, Composter, Algae farm 2, Tree seed generator 1, Induction furnace 1, Casting Machine 1, Blast furnace 1, simple-io, Электрическая лаборатория) плюс отдельно подтверждённые `assembling-machine-2` и `advanced-circuit`.

Прогрессия слотов сохранена:
- AM1=6 < AM2=7 < AM3=9 < AM4=12 < AM5=15 < AM6=20
- em-1=6 < em-2=10 < em-3=16

Рецепты с 7+ ингредиентами (processing-unit=9, processors=7, god-module=11+, AM2/AM3 для тяжёлых тиеров) по-прежнему требуют сборщиков следующих тиеров.

Closes #190