### PR TITLE
Чинит дубль рецептов плавки свинца/олова и локализацию (fix #184)

### DIFF
--- a/mods/zzzparanoidal/data-final-fixes.lua
+++ b/mods/zzzparanoidal/data-final-fixes.lua
@@ -73,84 +73,37 @@ require("tweaks.custom.uniform-recipies")
 angelsmods.functions.OV.execute()
 
 -- ============================================================
--- ПРЯМЕ ВИПРАВЛЕННЯ РЕЦЕПТІВ ПЛАВКИ (після OV.execute)
--- Аналог iron-plate→ore1-crushed та copper-plate→ore3-crushed
+-- ПРЯМОЕ ИСПРАВЛЕНИЕ РЕЦЕПТОВ ПЛАВКИ (после OV.execute)
+-- Стратегия 1.1: модифицируем angels*-crushed-smelting in-place
+-- (7 crushed → 4 plate + 1 slag), как было в micro-final-fix.lua.
+-- bob-*-plate recipe остаётся скрытым силами angelssmelting'а.
 -- ============================================================
 
--- bob-lead-plate: замінюємо bob-lead-ore на angels-ore5-crushed (Rubyte)
-log("[NEXUS-UA] Starting bob-lead-plate fix, recipe exists: "..tostring(data.raw.recipe["bob-lead-plate"] ~= nil))
-if data.raw.recipe["bob-lead-plate"] then
-    local r = data.raw.recipe["bob-lead-plate"]
-    log("[NEXUS-UA] bob-lead-plate BEFORE: enabled="..tostring(r.enabled).." hidden="..tostring(r.hidden).." ings="..tostring(#(r.ingredients or {})))
-    r.enabled = true
-    r.hidden = false
-    r.category = "smelting"
-    r.localised_name = nil
+local function patch_crushed_smelting(recipe_name, crushed_name, plate_name)
+    local r = data.raw.recipe[recipe_name]
+    if not r then return end
     r.energy_required = 20
-    r.ingredients = { { type = "item", name = "angels-ore5-crushed", amount = 7 } }
+    r.ingredients = { { type = "item", name = crushed_name, amount = 7 } }
     r.results = {
-        { type = "item", name = "bob-lead-plate", amount = 4 },
+        { type = "item", name = plate_name, amount = 4 },
         { type = "item", name = "angels-slag", amount = 1 },
     }
-    r.icon = "__angelssmeltinggraphics__/graphics/icons/plate-lead.png"
-    r.icon_size = 32
-    r.icons = nil
-    log("[NEXUS-UA] bob-lead-plate set icon path: __angelssmeltinggraphics__/graphics/icons/plate-lead.png")
-    -- Видалити з локів технологій
-    for _, tech in pairs(data.raw.technology) do
-        if tech.effects then
-            for i = #tech.effects, 1, -1 do
-                if tech.effects[i].type == "unlock-recipe" and tech.effects[i].recipe == "bob-lead-plate" then
-                    table.remove(tech.effects, i)
-                end
-            end
-        end
+    r.main_product = plate_name
+    r.localised_name = { "item-name." .. plate_name }
+end
+
+-- Свинец (Rubyte): 7×ore5-crushed → 4×lead-plate + 1×slag
+patch_crushed_smelting("angels-ore5-crushed-smelting", "angels-ore5-crushed", "bob-lead-plate")
+
+-- Олово (Bobmonium): 7×ore6-crushed → 4×tin-plate + 1×slag
+patch_crushed_smelting("angels-ore6-crushed-smelting", "angels-ore6-crushed", "bob-tin-plate")
+
+-- Отключить raw-ore дубликаты (появились в 2.0; в 1.1 их не было)
+for _, name in ipairs({ "angels-ore5-smelting", "angels-ore6-smelting" }) do
+    if data.raw.recipe[name] then
+        data.raw.recipe[name].enabled = false
+        data.raw.recipe[name].hidden = true
     end
-end
-
--- bob-tin-plate: замінюємо bob-tin-ore на angels-ore6-crushed (Bobmonium)
-if data.raw.recipe["bob-tin-plate"] then
-    local r = data.raw.recipe["bob-tin-plate"]
-    r.enabled = true
-    r.hidden = false
-    r.category = "smelting"
-    r.localised_name = nil
-    r.energy_required = 20
-    r.ingredients = { { type = "item", name = "angels-ore6-crushed", amount = 7 } }
-    r.results = {
-        { type = "item", name = "bob-tin-plate", amount = 4 },
-        { type = "item", name = "angels-slag", amount = 1 },
-    }
-    r.icons = {
-        { icon = "__bobplates__/graphics/icons/plate/tin-plate.png", icon_size = 32 }
-    }
-    r.icon = nil
-    r.icon_size = 32
-    log("[NEXUS-UA] bob-tin-plate set icon path: __bobplates__/graphics/icons/plate/tin-plate.png")
-    for _, tech in pairs(data.raw.technology) do
-        if tech.effects then
-            for i = #tech.effects, 1, -1 do
-                if tech.effects[i].type == "unlock-recipe" and tech.effects[i].recipe == "bob-tin-plate" then
-                    table.remove(tech.effects, i)
-                end
-            end
-        end
-    end
-end
-
--- Відключити примітивні raw-ore рецепти (дублюють кращі crushed-ore варіанти)
--- angels-ore5-smelting: 1x Rubyte ore → 1x Lead plate (замінено на bob-lead-plate: 7x Crushed → 4x)
-if data.raw.recipe["angels-ore5-smelting"] then
-    data.raw.recipe["angels-ore5-smelting"].enabled = false
-    data.raw.recipe["angels-ore5-smelting"].hidden = true
-    log("[NEXUS-UA] angels-ore5-smelting: DISABLED + HIDDEN (replaced by bob-lead-plate)")
-end
-
--- angels-ore6-smelting: 1x Bobmonium ore → 1x Tin plate (замінено на bob-tin-plate: 7x Crushed → 4x)
-if data.raw.recipe["angels-ore6-smelting"] then
-    data.raw.recipe["angels-ore6-smelting"].enabled = false
-    data.raw.recipe["angels-ore6-smelting"].hidden = true
-    log("[NEXUS-UA] angels-ore6-smelting: DISABLED + HIDDEN (replaced by bob-tin-plate)")
 end
 
 --должно быть последним. После всех рецептов.


### PR DESCRIPTION
Closes #184. Заодно убирает дубль крафта из #190.

## Контекст

В 2.0 для свинца и олова в меню крафта висело **по два рецепта на одну и ту же руду**, и один из них с ломаным именем:

- `bob-lead-plate` — 7×`angels-ore5-crushed` → 4×plate + 1×slag, **название "Unknown key: recipe-name.bob-lead-plate"**
- `angels-ore5-crushed-smelting` — 1×`angels-ore5-crushed` → 1×plate, **название "Unknown key: recipe-name.angels-ore5-crushed-smelting"**
- (аналогично для олова: `bob-tin-plate` vs `angels-ore6-crushed-smelting`)

В 1.1 модпак делал это иначе — вместо создания отдельного `bob-*-plate` рецепта он **модифицировал `angelsore5/6-crushed-smelting` in-place** через `bobmods.lib.recipe.set_*` (`zzzparanoidal/prototypes/micro-final-fix.lua:269-278` версии 1.1). При синхронизации с 2.0 стратегия поменялась и дала дубль.

## Что изменено

`mods/zzzparanoidal/data-final-fixes.lua` — возвращена 1.1-стратегия:

- **Вместо** перезаписи `bob-lead-plate` / `bob-tin-plate` рецептов — **in-place мутация** `angels-ore5-crushed-smelting` / `angels-ore6-crushed-smelting` до баланса **7×crushed → 4×plate + 1×slag** (energy 20). `bob-*-plate` рецепты остаются скрытыми силами `angelssmelting`'а (его `OV.hide_recipe` + `OV.disable_recipe`), отдельно их трогать не нужно.
- **Локализация:** на изменённых рецептах выставляем `main_product = "bob-{lead,tin}-plate"` + `localised_name = { "item-name.bob-{lead,tin}-plate" }`. Ключи уже существуют в `bobplates/locale/ru/bobplates.cfg` ("Свинцовая пластина" / "Оловянная пластина") — название подтягивается автоматически без правок .cfg.

## Что удалено и почему

- **Блок переписывания `bob-lead-plate`** (~30 строк): мутации `enabled/hidden/category/icons/ingredients/results` + цикл по `data.raw.technology` для зачистки `unlock-recipe`. Всё это больше не нужно — рецепт теперь модифицируется в существующей техноцепочке angelsrefining'а, а сам `bob-lead-plate` остаётся скрытым angelssmelting'ом, как и задумано upstream.
- **Аналогичный блок для `bob-tin-plate`** (~30 строк) — по тем же причинам.
- **Debug-логи `[NEXUS-UA]`** — остатки одноразовой диагностики при портировании из 1.1, в production-коде ни к чему.
- **Явные присваивания `category = "smelting"`, `icon = ...`, `icon_size = 32`, `icons = nil`** — наследуются от angels-рецепта, дублировать незачем.

## Что сохранено

- **Отключение raw-ore дубликатов `angels-ore5-smelting` / `angels-ore6-smelting`** (появились только в 2.0, в 1.1 их не было). Оставлено как `enabled = false; hidden = true`.

## Проверка

После рестарта:
- В меню крафта/FNEI один рецепт на pure свинец (`angels-ore5-crushed-smelting`) с названием **"Свинцовая пластина (Рецепт)"** и содержимым 7→4+slag.
- Аналогично один рецепт на олово с названием **"Оловянная пластина (Рецепт)"** и 7→4+slag.
- `bob-lead-plate` / `bob-tin-plate` как рецепты **не показываются**.