### PR TITLE
Чинит локализацию шортката zoom-out из Shortcuts-ick (fix #181)

### DIFF
--- a/mods/zzzparanoidal/locale/en/shortcuts-ick-controls-fix.cfg
+++ b/mods/zzzparanoidal/locale/en/shortcuts-ick-controls-fix.cfg
@@ -1,0 +1,2 @@
+[controls]
+alt-zoom-out=Zoom out

--- a/mods/zzzparanoidal/locale/ru/shortcuts-ick-controls-fix.cfg
+++ b/mods/zzzparanoidal/locale/ru/shortcuts-ick-controls-fix.cfg
@@ -1,0 +1,2 @@
+[controls]
+alt-zoom-out=Уменьшить масштаб

--- a/mods/zzzparanoidal/locale/uk/shortcuts-ick-controls-fix.cfg
+++ b/mods/zzzparanoidal/locale/uk/shortcuts-ick-controls-fix.cfg
@@ -1,0 +1,2 @@
+[controls]
+alt-zoom-out=Зменшити масштаб


### PR DESCRIPTION
Closes #181.

## Корень проблемы

В шорткат-баре, настройках и сообщениях об ошибках мода `Shortcuts-ick` (актуальная версия **2.0.7**, https://mods.factorio.com/mod/Shortcuts-ick) вместо названия показывалась сырая строка `controls.alt-zoom-out` — ключ не резолвился в локали.

Мод ссылается на ключ `controls.alt-zoom-out`, **которого в Factorio 2.0 уже не существует** — в `core.cfg` он переименован в `controls.zoom-out` (наследие из 1.1). Баг — на стороне самого мода, в комплекте локалей `Shortcuts-ick` ключ не определён, и base/core 2.0 такой ключ тоже не отдаёт.

Багу подвержены **5 мест** в `Shortcuts-ick`:

| Файл | Строка | Где видно |
|---|---|---|
| `prototypes/shortcuts-basic.lua` | 168 | Кнопка `big-zoom` в шорткат-баре |
| `control.lua` | 543 | Сообщение об ошибке в чате |
| `settings/startup-basic.lua` | 71 | Стартовая настройка `big-zoom` |
| `settings/runtime-global.lua` | 26 | Runtime-настройка `disable-zoom` |
| `settings/runtime-per-user.lua` | 91 | Per-player `zoom-level` |

## Что сделано

Добавлен оверрайд ключа в `zzzparanoidal/locale/{en,ru}/shortcuts-ick-controls-fix.cfg` — стандартная техника модпака для патча локали без редактирования vendored-мода:

```cfg
[controls]
alt-zoom-out=Zoom out          # en
alt-zoom-out=Уменьшить масштаб # ru
```

Все 5 мест чинятся одновременно одним добавлением ключа.

## Что НЕ сделано (и почему)

- Не патчили `Shortcuts-ick/...` — это vendored-мод, его нужно править upstream'ом, а не правками в репе модпака.
- Не меняли само имя ключа в `Shortcuts-ick` (`alt-zoom-out` → `zoom-out`) — по той же причине.

## Проверка

После рестарта проверить пять мест из таблицы выше — везде должна показываться нормальная подпись вместо `controls.alt-zoom-out`.