### PR TITLE
Чинит названия и иконки рецептов electrolysis-x (Ni/Zn/Co/Ti)

### DIFF
--- a/mods/zzzparanoidal/prototypes/recipe/metallurgy.lua
+++ b/mods/zzzparanoidal/prototypes/recipe/metallurgy.lua
@@ -185,10 +185,12 @@ data:extend({
 	{
 		type = "recipe",
 		name = "bob-nickel-electrolysis-x",
+		main_product = "bob-nickel-plate",
+		localised_name = { "item-name.bob-nickel-plate" },
 		icons = {
 			{
 				icon = "__bobplates__/graphics/icons/plate/nickel-plate.png",
-				icon_size = 32,
+				icon_size = 64,
 				icon_mipmaps = 4,
 			},
 			{
@@ -218,6 +220,8 @@ data:extend({
 	{
 		type = "recipe",
 		name = "bob-zinc-electrolysis-x",
+		main_product = "bob-zinc-plate",
+		localised_name = { "item-name.bob-zinc-plate" },
 		icons = {
 			{
 				icon = "__bobplates__/graphics/icons/plate/zinc-plate.png",
@@ -251,10 +255,12 @@ data:extend({
 	{
 		type = "recipe",
 		name = "cobalat-electrolysis-x",
+		main_product = "bob-cobalt-plate",
+		localised_name = { "item-name.bob-cobalt-plate" },
 		icons = {
 			{
 				icon = "__bobplates__/graphics/icons/plate/cobalt-plate.png",
-				icon_size = 32,
+				icon_size = 64,
 				icon_mipmaps = 4,
 			},
 			{
@@ -266,7 +272,7 @@ data:extend({
 			},
 		},
 		subgroup = "angels-smelting",
-		order = "f[ingot-zinc]-d",
+		order = "f[ingot-cobalt]-d",
 		category = "angels-petrochem-electrolyser",
 		enabled = false,
 		energy_required = 17,
@@ -288,6 +294,8 @@ data:extend({
 	{
 		type = "recipe",
 		name = "bob-titanium-electrolysis-x",
+		main_product = "bob-titanium-plate",
+		localised_name = { "item-name.bob-titanium-plate" },
 		icons = {
 			{
 				icon = "__bobplates__/graphics/icons/plate/titanium-plate.png",
@@ -303,7 +311,7 @@ data:extend({
 			},
 		},
 		subgroup = "angels-smelting",
-		order = "f[ingot-zinc]-d",
+		order = "f[ingot-titanium]-d",
 		category = "angels-petrochem-electrolyser",
 		enabled = false,
 		energy_required = 22,


### PR DESCRIPTION
## Проблема

Четыре рецепта в `mods/zzzparanoidal/prototypes/recipe/metallurgy.lua`:

- `bob-nickel-electrolysis-x`
- `bob-zinc-electrolysis-x`
- `cobalat-electrolysis-x` (опечатка `cobalat` пришла из 1.1 KaoExtended; не правлю — сломаются ссылки)
- `bob-titanium-electrolysis-x`

В UI/FNEI/helmod показывались как **«Unknown key: recipe-name.bob-X-electrolysis-x»**. У nickel и cobalt вдобавок отображалась только **верхняя-левая четверть** иконки пластины.

## Корни

### 1. Имя

Те же грабли, что в #184/#204. Все 4 рецепта имеют **несколько `results`** (plate + газы/слаги/электрод), при этом `localised_name = nil` и `main_product = nil`. В Factorio 2.0 при >1 result автоматический fallback на имя/иконку первого продукта **не работает** — нужен явный `main_product` или `localised_name`.

Добавлено для каждого рецепта:

```lua
main_product = "bob-{nickel,zinc,cobalt,titanium}-plate",
localised_name = { "item-name.bob-{...}-plate" },
```

Ключи `item-name.bob-*-plate` уже есть в `bobplates/locale/ru/bobplates.cfg` («Никелевая пластина», «Цинковая пластина», «Кобальтовая пластина», «Титановая пластина») — никаких новых .cfg не нужно.

### 2. Иконки

Реальные размеры файлов:

| Файл | Реальный | Было в коде | Стало |
|---|---|---|---|
| `bobplates/.../nickel-plate.png`   | **64×64** | 32 | **64** ✓ |
| `bobplates/.../cobalt-plate.png`   | **64×64** | 32 | **64** ✓ |
| `bobplates/.../zinc-plate.png`     | 33×32 (апстрим-баг bobplates'а — не квадрат) | 32 | 32 (оставлен) |
| `bobplates/.../titanium-plate.png` | 32×32 | 32 | 32 (корректно) |

Когда `icon_size = 32` стоит на файле 64×64, Factorio читает только top-left 32×32 пиксел — отсюда «обрезанная» иконка. Поправлено только там, где это реально кропает (nickel и cobalt).

Корни 1.1: KaoExtended-овский `Bobs-alloy-recipe.lua` использовал файлы `*-128.png` с `icon_size = 128`. При 2.0-порте файлы заменили на стандартные bobplates'ы, а `icon_size` оставили жёстко `32` без проверки реального размера.

## Сравнение баланса с 1.1

Идентичны:

| | 1.1 | 2.0 |
|---|---|---|
| nickel | 12 сек, 10 ore + 100 water → 1 plate + 20 oxygen | те же числа, ore/plate/oxygen с `bob-`/`angels-` префиксами |
| zinc | 14 сек, 10 ore + 100 water → 1 plate + 25 oxygen | то же |
| cobalt | 17 сек, 14 ore + electrode + purified water → 1 plate + газы + slag + used electrode | то же |
| titanium | 22 сек, 14 ore + electrode + purified water → 1 plate + газы + slag + used electrode | то же |

Префиксы `bob-`/`angels-` — стандартный 2.0-ренейм item-имён, не функциональное изменение.

## Diff

```
1 file changed, 10 insertions(+), 2 deletions(-)
```

## Проверка

После рестарта (тестировал локально с временным `enabled = true` на всех 4 рецептах):

- В FNEI/helmod все 4 рецепта показывают нормальные имена «Никелевая пластина (Рецепт)», «Цинковая пластина», «Кобальтовая пластина», «Титановая пластина».
- У nickel и cobalt иконки пластин теперь отображаются полностью.
- Zinc остался с известным апстрим-багом (33×32 файл) — визуально это 1 потерянный пиксел, имхо незаметно.