### PR TITLE
Чинит ранний rail: подменяет sand на angels-solid-sand в concrete

### DIFF
--- a/mods/zzzparanoidal/final-fixes/recipies.lua
+++ b/mods/zzzparanoidal/final-fixes/recipies.lua
@@ -803,3 +803,18 @@ paralib.bobmods.lib.recipe.set_ingredients("bob-basic-circuit-board", {
 })
 
 paralib.bobmods.lib.recipe.replace_ingredient("bi-bio-farm", "stone-crushed", "stone-brick");
+
+-- aai-industry ввёл айтем sand и завязал на него concrete (5 stone-brick + 10 sand + 2 iron-stick + 100 water).
+-- Vanilla sand производится только из bob-quartz (через angels-ore-sorting-2/3/4 — поздняя цепочка),
+-- а angels-цепочка делает angels-solid-sand и concrete её не принимает. Из-за этого блокируется ранний rail.
+-- Чиним: подменяем sand → angels-solid-sand в concrete и прячем aai-шный sand, чтобы не дублировался в FNEI.
+if data.raw.recipe["concrete"] and data.raw.item["angels-solid-sand"] then
+	paralib.bobmods.lib.recipe.replace_ingredient("concrete", "sand", "angels-solid-sand")
+	if data.raw.recipe["sand"] then
+		data.raw.recipe["sand"].enabled = false
+		data.raw.recipe["sand"].hidden = true
+	end
+	if data.raw.item["sand"] then
+		data.raw.item["sand"].hidden = true
+	end
+end


### PR DESCRIPTION
## Как было в 1.1

- Айтема `sand` в модпаке **не существовало** — никто его не вводил.
- Песчаная цепочка целиком жила на `angels-solid-sand`: его делает `angels-water-treatment` (washing-plant) и `bi-sand` (`2 stone-crushed → 5 angels-solid-sand`).
- Рецепт **concrete** в `mods/aai-industry/prototypes/recipe/recipe-update.lua:142` (1.1): `5 stone-brick + 4 iron-stick + 100 water → 10 concrete`. **Без песка.**
- Рецепт **rail** (Bio_Industries 1.1 + marathon + zzzparanoidal): `~10 stone-crushed + 6 concrete + iron-stick + steel-plate → 2 rail`. Concrete не требует песка → rail доступен с раннего этапа.

## Как стало в 2.0

- **aai-industry 0.6.16 ввёл айтем `sand`** (`mods/aai-industry/prototypes/phase-1/item/item.lua:8` — `aai_sand_name = "sand"`). Его таблица совместимости (`compat-util.lua:3-10`) знает только `["sand", "kr-sand"]` — про `angels-solid-sand` она не в курсе.
- Рецепт **concrete переписан** (`mods/aai-industry/prototypes/phase-1/recipe/base-recipe-changes.lua:165-175`): `5 stone-brick + 10 sand + 2 iron-stick + 100 water → 10 concrete`. **Появилось обязательное требование sand.**
- Рецепт **получения `sand`** (от aai): `1 bob-quartz → 2 sand`. Категория стандартная crafting.
- `bob-quartz` производится **только** через `angels-ore-sorting-2/3/4` (chunk/crystal/pure-processing) — поздняя цепочка ангельского рефайнинга.
- Bio_Industries_2 переписал **rail** (`mods/Bio_Industries_2/data-updates.lua:752-763`): убран `iron-stick`, добавлен `concrete`. Итог: `6 stone-crushed + 2 concrete + 1 steel-plate → 2 rail`. concrete тянет sand → rail тянет sand → ранняя металлургия упирается в стену.
- `bi-sand` (`Bio_Industries_2/data-updates.lua`) по-прежнему делает `angels-solid-sand`, **не** vanilla `sand` — в Helmod визуально выглядит как «есть путь», но в игре блок не стартует, потому что concrete просит именно `sand`.

## Причина

Пересечение зон ответственности **aai-industry** и **angels-petrochem/refining**:
- aai создаёт айтем `sand` и завязывает на него `concrete`, не учитывая, что angels уже владеет «своим» песком (`angels-solid-sand`).
- angels создаёт `angels-solid-sand` и не предоставляет моста к vanilla `sand`.
- Ни один из апстримов не делает adapter — каждый считает свой айтем единственно верным.

Конкретный сломанный путь:
**`mods/aai-industry/prototypes/phase-1/recipe/base-recipe-changes.lua:165-175`** — рецепт `concrete` со ссылкой на `sand`, который реально достижим только через `angels-ore-sorting-2+`.

В 1.1 проблемы не было, потому что aai 1.1 в `recipe-update.lua:142` делал concrete без песка вовсе. Конфликт появился именно с релизом aai 0.6.x под Factorio 2.0.

## Суть фикса

Точечно в `mods/zzzparanoidal/final-fixes/recipies.lua` под guard'ом «оба айтема существуют»:

```lua
if data.raw.recipe["concrete"] and data.raw.item["angels-solid-sand"] then
    paralib.bobmods.lib.recipe.replace_ingredient("concrete", "sand", "angels-solid-sand")
    if data.raw.recipe["sand"] then
        data.raw.recipe["sand"].enabled = false
        data.raw.recipe["sand"].hidden = true
    end
    if data.raw.item["sand"] then
        data.raw.item["sand"].hidden = true
    end
end
```

1. Подменяем ингредиент `sand` на `angels-solid-sand` в `concrete`.
2. Отключаем тупиковый рецепт aai `1 bob-quartz → 2 sand` и скрываем сам айтем — чтобы не торчал в FNEI/Helmod как мусор.

## Почему именно этот фикс правильный

1. **Минимум диффа** (одна область в одном файле, ~15 строк) — не трогаем сторонние моды и не плодим новых рецептов в дереве.
2. **Идеологически совпадает с 1.1** — там «правильным песком» был именно `angels-solid-sand`. Возвращаемся к этому состоянию.
3. **Перекрывает всех реальных потребителей aai-sand.** Я проверил дамп `data.raw` — `sand` потребляют ровно два рецепта:
   - `concrete` — починен.
   - `bob-glass` — у него `hidden = true` и `localised_name = { "item-name.angels-void" }` (через `angelssmelting/prototypes/override/smelting-override-glass.lua:45` `OV.disable_recipe(\"bob-glass\")`); реальное стекло в модпаке делается через `angels-plate-glass`/`pmma-glass`/`pc-glass`/`glass-from-ore4`. Этот фолбек не дёргается, фикс ему не нужен.
4. **Не ломается, если порядок мод-апдейтов изменится** — guard `if data.raw.item[\"angels-solid-sand\"]` гарантирует, что без angels модпак продолжит работать (хотя такой конфигурации у нас нет).
5. **Альтернативы хуже:**
   - Добавить мост-рецепт `angels-solid-sand → sand` (вариант B) → лишняя сущность в дереве, два «песка» сосуществуют.
   - Переопределить рецепт `sand` (вариант C) → дублирует функцию `bi-sand`, теряется ангельский «правильный путь».
   - Полное item-merge через миграцию (вариант D) → требует .lua-миграции инвентарей, инвазивно, не оправдано (старых saves с накопленным `sand` у игроков нет — он только-только появился в 2.0).
   - Полное удаление `data.raw.item[\"sand\"] = nil` → бы сломало невидимый рецепт `bob-glass` (он всё ещё ссылается на айтем по имени) и подобные, а пользы никакой.

## Тест

Проверено вживую — после фикса блок `rail/concrete/sand/stone-crushed` в Helmod и в самой игре собирается на ранней стадии (washing-plant + дробилка), без необходимости пробивать `angels-ore-sorting-2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)