### PR TITLE
Поднимает tier-1 модули до синих банок под их пререквизиты

### DIFF
--- a/mods/zzzparanoidal/final-fixes/technologies.lua
+++ b/mods/zzzparanoidal/final-fixes/technologies.lua
@@ -343,6 +343,15 @@ if data.raw.technology["modules"] then
 		{ "chemical-science-pack", 1 },
 	}) --модули теперь за синие банки (как и должно быть)
 end
+for _, tier1_module in ipairs({ "speed-module", "efficiency-module", "productivity-module" }) do
+	if data.raw.technology[tier1_module] then
+		paralib.bobmods.lib.tech.set_science_packs(tier1_module, {
+			{ "automation-science-pack", 1 },
+			{ "logistic-science-pack", 1 },
+			{ "chemical-science-pack", 1 },
+		}) --tier-1 модули за синие банки, иначе цена ниже их пререквизитов (gold-smelting-1 / metallurgy-3)
+	end
+end
 if data.raw.technology["bob-drills-2"] then
 	paralib.bobmods.lib.tech.set_science_packs("bob-drills-2", {
 		{ "automation-science-pack", 1 },


### PR DESCRIPTION
## Причина

У трёх tier-1 module-техов (`speed-module`, `efficiency-module`, `productivity-module`) цена была дешевле, чем у их собственных пререквизитов — инверсия прогрессии:

| тех | банки | count |
|---|---|---|
| `angels-metallurgy-3` (предок) | red + green + **blue** | 150 |
| `angels-gold-smelting-1` (предок, требует metallurgy-3) | red + green + **blue** | 200 |
| `modules` (umbrella, требует gold-smelting-1) | red + green + **blue** | 25 |
| **`speed-module` / `efficiency-module` / `productivity-module`** ← было | red + green | 50 |

То есть чтобы вообще открыть модульный тех, игрок уже исследовал три blue-теха, а сам tier-1 разблокировался за red+green — это абсурдно дёшево относительно цепочки.

## Что сделано

В `mods/zzzparanoidal/final-fixes/technologies.lua` добавлен цикл, проставляющий всем трём tier-1 модулям пакеты `red + green + blue` (count остался **50**).

## Цены до/после и сравнение с tier-2

| Тех | Было | Стало | Tier-2 (для сверки) |
|---|---|---|---|
| `speed-module` | 50 × (red + green) | **50 × (red + green + blue)** | `speed-module-2`: 100 × (red + green + blue) |
| `efficiency-module` | 50 × (red + green) | **50 × (red + green + blue)** | `efficiency-module-2`: 100 × (red + green + blue) |
| `productivity-module` | 50 × (red + green) | **50 × (red + green + blue)** | `productivity-module-2`: 100 × (red + green + blue) |

Tier-2 техи остаются ровно вдвое дороже tier-1 по count и имеют тот же набор банок — естественная прогрессия `tier-1 (50) → tier-2 (100)` сохранена. Просто tier-1 теперь не дешевле своих собственных пререквизитов.

## Test plan

- [x] Открыть tech tree, посмотреть стоимость `speed-module` / `efficiency-module` / `productivity-module`: должно быть 50 × red+green+blue
- [x] Проверить, что tier-2 module-техи (`*-module-2`) по-прежнему 100 × red+green+blue
- [x] Убедиться, что umbrella `modules` (25 × red+green+blue) и `angels-gold-smelting-1` остались как были

🤖 Generated with [Claude Code](https://claude.com/claude-code)