### PR TITLE
Чинит заправку offshore-mk0-pump обработанным топливом из aai-industry

### DIFF
--- a/mods/zzzparanoidal/prototypes/entity/offshore-pumps.lua
+++ b/mods/zzzparanoidal/prototypes/entity/offshore-pumps.lua
@@ -16,7 +16,10 @@ end
 local energySources = {
 	burner = {
 		type = "burner",
-		fuel_categories = { "chemical" },
+		fuel_categories = {
+			"chemical",
+			data.raw["fuel-category"]["processed-chemical"] and "processed-chemical" or nil,
+		},
 		effectivity = 1,
 		fuel_inventory_size = 1,
 		emissions_per_minute = { pollution = 9 },


### PR DESCRIPTION
## Симптом

В `offshore-mk0-pump` (бернерный «первый насос» из zzz) нельзя залить **«Обработанное топливо»** (`processed-fuel` из aai-industry). Обычные `chemical`-топлива (уголь, дрова, кокс из petrochem, bob-carbon, и т.п.) — лезут штатно.

## Корень

`aai-industry` 2.0 разделил топливо на две fuel-категории:

- `chemical` — базовая, всё что было всегда.
- `processed-chemical` — новая, для `processed-fuel` (`mods/aai-industry/prototypes/phase-1/combined/processed-fuel.lua`).

Чтобы все горелки модпака продолжали есть и то и другое, `aai-industry` в `data-final-fixes.lua` бежит по `data.raw` и автодобавляет `processed-chemical` в `fuel_categories` всем burner-сущностям этих типов:

```
assembling-machine, beacon, boiler, burner-generator, car, spider-vehicle,
furnace, inserter, lab, locomotive, mining-drill, reactor, generator-equipment
```

Тип `offshore-pump` в этот список **не попал**. `offshore-mk0-pump` объявлен в `mods/zzzparanoidal/prototypes/entity/offshore-pumps.lua:19` с `fuel_categories = { "chemical" }` и остаётся без `processed-chemical`.

## Регрессия из 1.1

В 1.1 этой проблемы не было:

1. `aai-industry` 9.2.4 (версия из 1.1-копии модпака) **вообще не имел** категории `processed-chemical` — `processed-fuel` и все горелки сидели в одной общей `fuel_category = "chemical"`.
2. У `offshore-pump` в 1.1 API ещё не было `energy_source`, и zzz обходил это через парную сущность `*-output` типа `pump` с burner-источником. Эту парную pump-сущность ai-industry'шный авто-патч и так бы захватывал в новом split-сценарии (тип `pump` тоже не в списке, но в 1.1 split'а не существовало).

В 2.0 zzz упростил архитектуру до прямого `burner` на `offshore-pump` — что само по себе корректно, но столкнулось с не-обновлённым списком типов в авто-патче ai-industry.

## Фикс

Точечный — в `mods/zzzparanoidal/prototypes/entity/offshore-pumps.lua:19`. Добавляю `\"processed-chemical\"` в `fuel_categories` условно, по образцу того, как это пишет сам ai-industry в `prototypes/phase-1/entity/entity-burner-lab.lua`:

```lua
fuel_categories = {
    \"chemical\",
    data.raw[\"fuel-category\"][\"processed-chemical\"] and \"processed-chemical\" or nil,
},
```

Категория добавляется только если её зарегистрировал ai-industry — без обязательной зависимости.

## Область

В текущем модсете это единственная регрессия такого типа:

- единственный burner-`offshore-pump` модпака — `offshore-mk0-pump`;
- единственный айтем в `processed-chemical` — `processed-fuel` (aai-industry).

Никаких общих обходов по data.raw не требуется.

## Проверено

После правки насос принимает обработанное топливо в инвентарь и нормально на нём работает; обычные `chemical`-топлива продолжают лезть.