### PR TITLE
Возвращает peaceful-режим guard в Big-Monsters

### DIFF
--- a/docs/Mod-Patches.md
+++ b/docs/Mod-Patches.md
@@ -1,0 +1,40 @@
+# Патчи в сторонних модах
+
+Список локальных правок, наложенных на вендорные сторонние моды (всё, что лежит в `mods/` и не наше). Нужен, чтобы при апдейте мода знать: что именно мы патчили и можно ли уже снять патч (если апстрим починил).
+
+## Формат записи
+
+Каждый патч описывается блоком:
+
+- **Мод** — имя папки в `mods/`.
+- **Версия на момент патча** — из `info.json` мода.
+- **Файл и строка** — где правили.
+- **Симптом** — как баг проявляется в игре.
+- **Суть патча** — одной строкой что меняем.
+- **PR** — ссылка на PR в этом репозитории, в рамках которого патч был наложен.
+- **Статус** — `активен` / `можно снять (апстрим починил в X.Y.Z)` / `постоянный (наша спец. логика)`.
+
+При обновлении мода:
+1. Сравнить новую версию мода со «версией на момент патча».
+2. Проверить, ушёл ли затронутый код / починили ли симптом.
+3. Если да — удалить патч из мода и запись из этого файла. Если нет — переналожить патч на новую версию и обновить «версию на момент патча».
+
+---
+
+## Патчи
+
+### Big-Monsters: guard на peaceful-режим
+
+- **Мод:** `Big-Monsters` (автор MFerrari).
+- **Версия на момент патча:** 2.1.2.
+- **Файл и строка:**
+  - `mods/Big-Monsters/control.lua` — helper `bm_peaceful_skip` после `require`-блока; вызов в `CreateNewEvent` сразу после проверки force/surface; вызов в `Create_Position_Event` после проверки `surface.valid`; вызов в `Call_next_wave` внутри цикла по `attacks`; вызов в `On_Built` перед прямым `CallFrenzyAttack` (атака при постройке rocket-silo).
+  - `mods/Big-Monsters/settings.lua` — определение `bm-events-when-peaceful` (runtime-global bool, default `false`).
+  - `mods/Big-Monsters/locale/en/en.cfg` — `mod-setting-name` и `mod-setting-description` для настройки.
+  - `mods/Big-Monsters/locale/ru/ru.cfg` — **новый файл** (в апстриме папки `ru/` нет), RU-локаль для настройки.
+- **Симптом:** на peaceful-сёрфейсах Big-Monsters всё равно спавнит swarm / invasion / volcano / biterzilla / human soldiers и шлёт красные алерты в чат, независимо от `surface.peaceful_mode` карты.
+- **Суть патча:** `bm_peaceful_skip(surface)` возвращает `true` если `surface.peaceful_mode` или `map_gen_settings.autoplace_controls["enemy-base"].size == 0`; на «true» event-функции делают ранний `break`/`return`. Перебивается runtime-настройкой `bm-events-when-peaceful` для редкого сценария «играем peaceful по ванилле, но скриптовые сюрпризы Big-Monsters хочу оставить».
+- **PR:** [#220](https://github.com/FactorioParanoidal/ParanoidalModpack/pull/220).
+- **Статус:** активен. Аналогичный патч был в 1.1-сборке; при порте мода MFerrari на 2.0 проверки потерялись, upstream-патч пока не отправлен.
+
+Полный апстрим-ready diff: `git diff master..fix/big-monsters-peaceful-mode-guard -- mods/Big-Monsters/` или см. PR-changes.

--- a/mods/Big-Monsters/control.lua
+++ b/mods/Big-Monsters/control.lua
@@ -10,6 +10,19 @@ require "__mferrari_lib__/stdlib/area/chunk"
 require "__mferrari_lib__/stdlib/area/area"
 
 
+-- Skip event spawning on peaceful surfaces or on maps generated with
+-- enemy-base size = 0 (i.e. no enemies expected). Can be overridden via
+-- runtime setting "bm-events-when-peaceful" (default off).
+local function bm_peaceful_skip(surface)
+    if not surface or not surface.valid then return true end
+    if settings.global["bm-events-when-peaceful"] and settings.global["bm-events-when-peaceful"].value then return false end
+    if surface.peaceful_mode then return true end
+    local ac = surface.map_gen_settings and surface.map_gen_settings.autoplace_controls
+    if ac and ac["enemy-base"] and ac["enemy-base"].size == 0 then return true end
+    return false
+end
+
+
 function ReadRunTimeSettings(event)
 storage.chances = storage.chances or {}  -- in priority order of danger
 storage.chances.volcano       = {min_evo=settings.global["bm-volcano-min_evo"].value  		, chance=settings.global["bm-volcano-chance"].value, max_evo=settings.global["bm-volcano-max_evo"].value}
@@ -187,7 +200,8 @@ if not evo then evo=get_evo_here(surface) end
 
 for p=1,#storage.player_forces do
 	local pforce = game.forces[storage.player_forces[p]]
-	if surface and the_event and pforce and (not surfacename or surface.name==surfacename) and (not forcename or pforce.name==forcename) then 
+	if surface and the_event and pforce and (not surfacename or surface.name==surfacename) and (not forcename or pforce.name==forcename) then
+		if bm_peaceful_skip(surface) then break end
 		local player_spawn = pforce.get_spawn_position(surface)
 		local pcount = count_players_on_surface(surface, pforce)
 
@@ -344,6 +358,7 @@ end
 
 function Create_Position_Event(the_event, surface, position, pforce)
 if not (surface and surface.valid) then return end
+if bm_peaceful_skip(surface) then return end
 local pcount = math.max(1,count_players_on_surface(surface, pforce)) --1 min to avoid crashes
 local evo = get_evo_here(surface)
 
@@ -632,12 +647,12 @@ end
 
 
 function Call_next_wave(event)
-local event_name = event.event_name 
-if event_name == 'swarm' then 
+local event_name = event.event_name
+if event_name == 'swarm' then
 	local attacks = event.attacks
 	for a=1,#attacks do
 		local at = attacks[a]
-		if at.surface and at.surface.valid then CallFrenzyAttack(at.surface,at.target,at.limit,at.multiplier) end
+		if at.surface and at.surface.valid and not bm_peaceful_skip(at.surface) then CallFrenzyAttack(at.surface,at.target,at.limit,at.multiplier) end
 		end
 	end
 end
@@ -1074,7 +1089,7 @@ if entity and entity.valid and entity.type~='entity-ghost' then
 	local surface = entity.surface
 --	local name=entity.name 
 	table.insert (storage.rocket_silos,entity)
-	if storage.enable_silo_attack then CallFrenzyAttack(surface,entity,nil,1.5) end
+	if storage.enable_silo_attack and not bm_peaceful_skip(surface) then CallFrenzyAttack(surface,entity,nil,1.5) end
 	end
 end		
 local filters = {{filter = "name", name = "rsc-silo-stage1"}, {filter = "name", name = "rsc-silo-stage1-serlp"}, {filter = "name", name = "rocket-silo"}}

--- a/mods/Big-Monsters/locale/en/en.cfg
+++ b/mods/Big-Monsters/locale/en/en.cfg
@@ -104,6 +104,7 @@ bm_camera_size=Camera size
 bm-demolisher-chance=Demolisher chance %
 bm-demolisher-min_evo=Demolisher minimal evolution
 bm-spawn_on_sa_planets=Allow spawn on Space Age planets
+bm-events-when-peaceful=Enabled in peaceful mode
 
 [mod-setting-description]
 bm-event-days=How often the attacks will happen (1 game day = 7 minutes). Values 0-20 (Zero = disable all)
@@ -134,6 +135,7 @@ bm-tree-events-chance=If a player mines a tree, this is the chance of something 
 bm-swarm-max_evo=If evolution if higher than this value, the event does not happen anymore
 bm-volcano-max_evo=If evolution if higher than this value, the event does not happen anymore
 bm-spawn_near_nests=Most enemy attacks will be spawned near enemy nests, if possible
+bm-events-when-peaceful=If enabled, events will occur even in peaceful mode
 
 
 [item-name]

--- a/mods/Big-Monsters/locale/ru/ru.cfg
+++ b/mods/Big-Monsters/locale/ru/ru.cfg
@@ -1,0 +1,5 @@
+[mod-setting-name]
+bm-events-when-peaceful=Включить события в мирном режиме
+
+[mod-setting-description]
+bm-events-when-peaceful=Если включено, события Big-Monsters будут происходить даже в мирном режиме (по умолчанию — на мирных поверхностях события подавлены).

--- a/mods/Big-Monsters/settings.lua
+++ b/mods/Big-Monsters/settings.lua
@@ -347,6 +347,14 @@ data:extend({
 		order = "z",
 	},
 
+	{
+		type = "bool-setting",
+		name = "bm-events-when-peaceful",
+		setting_type = "runtime-global",
+		default_value = false,
+		order = "z-peaceful",
+	},
+
 	-- per player
 	{
 		type = "bool-setting",


### PR DESCRIPTION
## Зачем

В 1.1-сборке у `Big-Monsters` (автор MFerrari) был наложен ParanoidalModpack-патч, который блокировал event-спавны на peaceful-поверхностях:

```lua
if (surface.peaceful_mode or surface.map_gen_settings.autoplace_controls["enemy-base"].size == 0)
   and not settings.global["bm-events-when-peaceful"].value then
    break
end
```

В 2.0 версии (`Big-Monsters` 2.1.2) MFerrari переписал `control.lua` и эти проверки **потерялись**. Сейчас в нашей сборке Big-Monsters спавнит swarms / invasions / volcanoes / human soldiers / biterzilla и шлёт красные алерты в чат **независимо** от того, что surface в `peaceful_mode`. Для не-агрессивных сейвов это ломает геймплей.

## Что делает PR

Восстанавливает guard в новой 2.1.2-структуре с той же setting-схемой, что в 1.1.

### `mods/Big-Monsters/control.lua`

- Helper `bm_peaceful_skip(surface)` в начале файла:
  - возвращает `true` если `surface.peaceful_mode == true` или `map_gen_settings.autoplace_controls["enemy-base"].size == 0`;
  - перебивается runtime-настройкой `bm-events-when-peaceful` (override).
- В `CreateNewEvent` — `break` сразу после проверки force/surface.
- В `Create_Position_Event` — `return` сразу после `surface.valid`-проверки.
- В `Call_next_wave` — пропуск `at`-attack'а, если его surface стал peaceful после планирования (edge-case с очередями `next_wave`).

### `mods/Big-Monsters/settings.lua`

- Новый `bm-events-when-peaceful` (runtime-global bool, default `false`). Видно в Settings → Mod settings → Map. Если включить — возвращается оригинальное 2.0-поведение (события идут в peaceful).

### `mods/Big-Monsters/locale/en/en.cfg`, `mods/Big-Monsters/locale/ru/ru.cfg`

- EN-локаль из 1.1 (`Enabled in peaceful mode` / `If enabled, events will occur even in peaceful mode`).
- RU-локаль — **новый файл** `locale/ru/ru.cfg`. В апстриме папки `ru/` не было, добавляем (`Включить события в мирном режиме`).

### `docs/Mod-Patches.md`

- **Новый документ** со сводным списком локальных правок сторонних модов и форматом записи. Этот патч — первая запись.

## Проверка во всех режимах

| Режим | Setting | Поведение |
|---|---|---|
| **Peaceful** | `false` (default) | События подавлены. Алертов нет, monsters не спавнятся. |
| **Peaceful** | `true` | События идут, alerts работают, monsters спавнятся (override). |
| **Non-peaceful** | `false` или `true` | События идут как в апстриме, независимо от setting. |

Дополнительно проверено через remote interface:
```
/c remote.call("bigmonster", "create_event", "swarm")
```
- галка ВЫКЛ + peaceful → ничего (guard сработал).
- галка ВКЛ + peaceful → красный алерт + спавн swarm-волны.
- non-peaceful → всегда срабатывает.

## Upstream-clean diff

Патч помечен как **upstream-ready** — никаких paranoidal-специфичных комментариев в коде. Полный diff на `mods/Big-Monsters/` можно отправить MFerrari одной командой:

```
git format-patch master..HEAD -- mods/Big-Monsters/
```

См. `docs/Mod-Patches.md` для полного diff'а и инструкции по сопровождению патча при обновлениях мода.