### PR TITLE
Прячет molten-steel-smelting-c2 (регрессия порта Clowns-Processing 1.1 → 2.0)

### DIFF
--- a/mods/zzzparanoidal/data-final-fixes.lua
+++ b/mods/zzzparanoidal/data-final-fixes.lua
@@ -61,6 +61,7 @@ require("removals.bio-modules")
 require("removals.fishes")
 require("removals.aai-medium-electric-pole")
 require("removals.alloy-mixer")
+require("removals.clowns-steel-c2")
 
 require("graphics.train.train_reskin") -- рескин поездов
 -------------------------------------------------------------------------------------------------

--- a/mods/zzzparanoidal/removals/clowns-steel-c2.lua
+++ b/mods/zzzparanoidal/removals/clowns-steel-c2.lua
@@ -1,0 +1,14 @@
+require("__zzzparanoidal__.paralib")
+-- В 1.1 Clowns-Processing/prototypes/recipes/angels-smelting.lua оборачивал
+-- molten-iron-smelting-6 и molten-steel-smelting-c2 в if/else: первый — для
+-- bobplates / angelsindustries-overhaul, второй — fallback "magnesium sink"
+-- для vanilla. При порте на 2.0 if/else потерян, обе ветки теперь
+-- добавляются всегда. В нашей сборке bobplates грузится, поэтому c2
+-- избыточен и создаёт коллизию метки "2" с angels-liquid-molten-steel-2.
+
+if
+	(mods["bobplates"] or (mods["angelsindustries"] and angelsmods.industries.overhaul))
+	and data.raw.recipe["molten-steel-smelting-c2"]
+then
+	paralib.bobmods.lib.recipe.hide("molten-steel-smelting-c2")
+end


### PR DESCRIPTION
## Кто виноват

`mods/Clowns-Processing/prototypes/recipes/angels-smelting.lua` — порт мода с 1.1 на 2.0.

## Какое условие пропало

В 1.1 эти два рецепта были взаимоисключающими через `if/else`:

```lua
if mods["bobplates"] or (mods["angelsindustries"] and angelsmods.industries.overhaul) then
  recipe[+1] = molten-iron-smelting-6       -- 12 iron + 12 magnesium + 12 manganese → 360 molten-iron
else                                          -- magnesium sink для vanilla
  recipe[+1] = molten-steel-smelting-c2     -- 12 steel + 12 magnesium + 12 phosphorus → 360 molten-steel
end
```

В 2.0 `if/else/end` потерян, обе ветки добавляются всегда. В нашей сборке bobplates грузится, поэтому `molten-steel-smelting-c2` лишний и:
- ломает баланс (даёт ещё один путь к molten-steel сверх 10 имеющихся в angelssmelting + extended-remelting);
- создаёт коллизию icon-layer метки «2» с `angels-liquid-molten-steel-2` (silicon-вариант) в Factoriopedia.

## Как пофиксили

Сторонний `Clowns-Processing` не трогаем. В zzz добавлен removal с тем же условием, что было в 1.1:

- `mods/zzzparanoidal/removals/clowns-steel-c2.lua` — при `mods["bobplates"]` или `angelsmods.industries.overhaul` прячет `molten-steel-smelting-c2` через `paralib.bobmods.lib.recipe.hide`.
- `mods/zzzparanoidal/data-final-fixes.lua` — регистрирует removal рядом с остальными.

`molten-iron-smelting-6` (полезная ветка для bobplates) не трогается.

🤖 Generated with [Claude Code](https://claude.com/claude-code)