### PR TITLE
Удаляет мёртвые локали JunkTrain3

### DIFF
--- a/mods/zzzparanoidal/locale/en/locale.cfg
+++ b/mods/zzzparanoidal/locale/en/locale.cfg
@@ -31,10 +31,6 @@ seafloor-pump-3=Extracts viscous mud water from a body of water.\n[font=default-
 
 [recipe-name]
 artillery-turret-prototype=Artillery Cannon Prototype
-scrap-rail-to-rail=Scrap-rail-to-rail enhancement
-rail-signal-scrap-to-rail-signal=Primitive Traffic Light Improvement
-rail-chain-signal-scrap-to-rail-chain-signal=Walkthrough Primitive Traffic Light Improvement
-train-stop-scrap-to-train-stop=Primitive Station Upgrade
 offshore-mk0-pump=Burner Pump
 offshore-pump=Electric Offshore Pump
 offshore-mk2-pump=Electric Offshore Pump MK2
@@ -63,9 +59,6 @@ molten-magnesium-remelting=Magnesium remelting
 copper-plate=Copper plate
 iron-plate=Iron plate
 
-
-[recipe-description]
-scrap-rail-to-rail=Replacing wooden sleepers with concrete
 
 [entity-name]
 artillery-turret-prototype=Artillery Cannon Prototype

--- a/mods/zzzparanoidal/locale/ru/locale.cfg
+++ b/mods/zzzparanoidal/locale/ru/locale.cfg
@@ -73,10 +73,6 @@ bi-bio-reactor-2=Биореактор используется для того, 
 bi-bio-reactor-3=Биореактор используется для того, что бы производить и перерабатывать биомассу.
 
 [recipe-name]
-scrap-rail-to-rail=Улучшение деревянных рельс
-rail-signal-scrap-to-rail-signal=Улучшение примитивного светофора
-rail-chain-signal-scrap-to-rail-chain-signal=Улучшение проходного примитивного светофора
-train-stop-scrap-to-train-stop=Улучшение примитивной станции
 bi-bio-farm-2=Биоферма МК2
 bi-bio-farm-3=Биоферма МК3
 bi-bio-greenhouse-2=Теплица MK2
@@ -97,7 +93,6 @@ copper-plate=Медная плита
 iron-plate=Железная плита
 
 [recipe-description]
-scrap-rail-to-rail=Замена деревянных шпал на бетонные
 seafloor-pump=Насос для размывания грунта и добычи грязной мутной взвеси.
 seafloor-pump-2=Насос для размывания грунта и добычи грязной мутной взвеси.
 seafloor-pump-3=Насос для размывания грунта и добычи грязной мутной взвеси.


### PR DESCRIPTION
В 1.1 был мод [JunkTrain3](https://mods.factorio.com/mod/JunkTrain3) (tier-0 поезда на красной науке: `JunkTrain`, `ScrapTrailer`, `scrap-rail`, `rail-signal-scrap`, `rail-chain-signal-scrap`, `train-stop-scrap`). zzz добавлял апгрейд-рецепты `scrap-rail-to-rail` и аналоги для сигналов/станции.

В 2.0 JunkTrain3 не порт ировали (последний релиз — 1.1.0 от 2020-11-29), мод из сборки выпал. Сами апгрейд-рецепты исчезли вместе с ним, но в `locale/{en,ru}/locale.cfg` остались осиротевшие ключи.

Удалено:
- `mods/zzzparanoidal/locale/en/locale.cfg`: 4 строки `[recipe-name]` (`scrap-rail-to-rail`, `rail-signal-scrap-to-rail-signal`, `rail-chain-signal-scrap-to-rail-chain-signal`, `train-stop-scrap-to-train-stop`) + опустевшая секция `[recipe-description]` со `scrap-rail-to-rail`.
- `mods/zzzparanoidal/locale/ru/locale.cfg`: те же 4 + 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)