### PR TITLE
Чинит Unknown key у рецепта glass-from-ore4

### DIFF
--- a/mods/zzzparanoidal/prototypes/recipe/glass.lua
+++ b/mods/zzzparanoidal/prototypes/recipe/glass.lua
@@ -3,6 +3,7 @@ data:extend({
 	{
 		type = "recipe",
 		name = "glass-from-ore4",
+		localised_name = { "item-name.bob-glass" },
 		category = "smelting",
 		group = "angels-casting",
 		subgroup = "angels-glass-casting",


### PR DESCRIPTION
В Factoriopedia / FNEI у рецепта `glass-from-ore4` (`mods/zzzparanoidal/prototypes/recipe/glass.lua`, 7×`angels-ore4-crushed` → 4×`bob-glass` + 1×`angels-slag`) показывается:

> Unknown key: "recipe-name.glass-from-ore4" (Рецепт)

Причина: мульти-результат + не выставлен ни `main_product`, ни `localised_name`. Factorio не делает fallback на item-name результата.

Фикс — `localised_name = { "item-name.bob-glass" }` в прототипе рецепта. Тот же паттерн, что у `patch_crushed_smelting` в `data-final-fixes.lua` для lead/tin. Никаких новых ключей в locale не нужно — переиспользуется уже существующее «Стекло» / «Glass» из bobplates.

После фикса рецепт отображается как «Стекло» (RU) / «Glass» (EN), консистентно с другими стекольными рецептами в Factoriopedia.

<img width="760" height="1342" alt="image" src="https://github.com/user-attachments/assets/f9e26d02-cfce-419a-b426-ab1c57b4e787" />