### PR TITLE
Возвращает T2 углерода в технологическое дерево

### DIFF
--- a/mods/zzzparanoidal/final-fixes/technologies.lua
+++ b/mods/zzzparanoidal/final-fixes/technologies.lua
@@ -185,11 +185,6 @@ paralib.bobmods.lib.tech.remove_recipe_unlock(
 paralib.bobmods.lib.tech.remove_recipe_unlock("angels-tungsten-smelting-1", "angels-tungsten-pipe-casting")
 paralib.bobmods.lib.tech.remove_recipe_unlock("angels-tungsten-smelting-1", "angels-tungsten-pipe-to-ground-casting")
 
---фикс кривых исследований углерода
-paralib.bobmods.lib.tech.remove_recipe_unlock("angels-coal-processing-2", "coke-purification-3")
-paralib.bobmods.lib.tech.remove_recipe_unlock("angels-coal-processing-3", "angels-coke-purification-2")
-paralib.bobmods.lib.tech.add_recipe_unlock("angels-coal-processing-3", "coke-purification-3")
-
 --фикс недоступности исследования артиллерии
 paralib.bobmods.lib.tech.remove_prerequisite("artillery", "radar")
 


### PR DESCRIPTION
## Симптом

В Factoriopedia виден рецепт `angels-coke-purification-2` (Coke purification, II badge: 4 coke + NaOH + 30 N₂ → 6 carbon + Na₂CO₃ + 10 water), но никаким исследованием он не открывается. Игрок с синей наукой не может им пользоваться, хотя по апстрим angelspetrochem он должен был открыться на технологии `angels-coal-processing-3` (50× red+green science).

## Причина

В `mods/zzzparanoidal/final-fixes/technologies.lua:188-191` был блок:

```lua
--фикс кривых исследований углерода
paralib.bobmods.lib.tech.remove_recipe_unlock("angels-coal-processing-2", "coke-purification-3")
paralib.bobmods.lib.tech.remove_recipe_unlock("angels-coal-processing-3", "angels-coke-purification-2")
paralib.bobmods.lib.tech.add_recipe_unlock("angels-coal-processing-3", "coke-purification-3")
```

Блок ссылается на рецепт `coke-purification-3`, который существовал только в **Oberhaul 1.1** (`mods/Oberhaul/prototypes/petrochemchange.lua` в 1.1-ветке). В 2.0 он не определён нигде — Oberhaul 2.0 его не сохранил, а angelspetrochem 2.0 свёл всю схему до двух тиров (`angels-solid-carbon` T1 + `angels-coke-purification-2` T2).

Итог:
- Третья строка добавляет unlock несуществующего прототипа → no-op.
- Вторая строка **снимает легитимный unlock T2** с `angels-coal-processing-3`.
- `angels-coke-purification-2` остаётся в `data.raw.recipe`, но без technology → невозможно изучить.

Регрессия попала в порт коммитом `9c2503acb` (SKProCH, 2026-04-13, «Синхронизация модов с VOLBAX2/Factorio2.0.73-SpaceAge-Paranoidal»).

## Фикс

Удалён весь блок (3 строки + комментарий). В 2.0 angelspetrochem сам правильно разводит:
- T1 (`angels-solid-carbon`) → `angels-coal-processing` (red)
- T2 (`angels-coke-purification-2`) → `angels-coal-processing-3` (red + green)

Никаких override'ов от zzz больше не нужно.

## Verification

После применения, в Lua-консоли:
```lua
/c
for _, e in pairs(game.forces.player.technologies["angels-coal-processing-3"].prototype.effects) do
  if e.type == "unlock-recipe" then game.print(e.recipe) end
end
```
Должно вывести `angels-pellet-coke` и `angels-coke-purification-2`.

В техе не было рецепта второго карбона
<img width="404" height="768" alt="image" src="https://github.com/user-attachments/assets/1e06e883-9c74-4298-9da0-0f9ec6e7a3c4" />
