### PR TITLE
Убирает дубли ингредиентов в рецептах электролайзеров, бойлеров и сливочной установки

### DIFF
--- a/mods/zzzparanoidal/final-fixes/recipies.lua
+++ b/mods/zzzparanoidal/final-fixes/recipies.lua
@@ -567,17 +567,6 @@ paralib.bobmods.lib.recipe.add_new_ingredient(
 	{ type = "item", name = "angels-chemical-plant-3", amount = 2 }
 )
 
-paralib.bobmods.lib.recipe.remove_ingredient("angels-electric-boiler-2", "angels-electric-boiler")
-paralib.bobmods.lib.recipe.add_new_ingredient(
-	"angels-electric-boiler-2",
-	{ type = "item", name = "angels-electric-boiler", amount = 2 }
-)
-paralib.bobmods.lib.recipe.remove_ingredient("angels-electric-boiler-3", "angels-electric-boiler-2")
-paralib.bobmods.lib.recipe.add_new_ingredient(
-	"angels-electric-boiler-3",
-	{ type = "item", name = "angels-electric-boiler-2", amount = 2 }
-)
-
 paralib.bobmods.lib.recipe.remove_ingredient("clowns-sluicer-2", "clowns-sluicer")
 paralib.bobmods.lib.recipe.add_new_ingredient("clowns-sluicer-2", { type = "item", name = "clowns-sluicer", amount = 2 })
 

--- a/mods/zzzparanoidal/tweaks/recipe/insert-structured-components.lua
+++ b/mods/zzzparanoidal/tweaks/recipe/insert-structured-components.lua
@@ -24,10 +24,6 @@ local function replaceMachine()
 		"angels-salination-plant-2",
 		{ type = "item", name = "advanced-structure-components", amount = 5 }
 	)
-	paralib.bobmods.lib.recipe.add_ingredient(
-		"angels-salination-plant-2",
-		{ type = "item", name = "angels-salination-plant", amount = 2 }
-	)
 
 	paralib.bobmods.lib.recipe.add_ingredient(
 		"angels-washing-plant-2",

--- a/mods/zzzparanoidal/tweaks/recipe/insert-structured-components.lua
+++ b/mods/zzzparanoidal/tweaks/recipe/insert-structured-components.lua
@@ -150,23 +150,6 @@ local function replaceMachine()
 	)
 
 	paralib.bobmods.lib.recipe.add_ingredient(
-		"angels-electrolyser",
-		{ type = "item", name = "basic-structure-components", amount = 1 }
-	)
-	paralib.bobmods.lib.recipe.add_ingredient(
-		"angels-electrolyser-2",
-		{ type = "item", name = "intermediate-structure-components", amount = 2 }
-	)
-	paralib.bobmods.lib.recipe.add_ingredient(
-		"angels-electrolyser-3",
-		{ type = "item", name = "intermediate-structure-components", amount = 8 }
-	)
-	paralib.bobmods.lib.recipe.add_ingredient(
-		"angels-electrolyser-4",
-		{ type = "item", name = "advanced-structure-components", amount = 2 }
-	)
-
-	paralib.bobmods.lib.recipe.add_ingredient(
 		"bob-electric-chemical-mixing-furnace",
 		{ type = "item", name = "intermediate-structure-components", amount = 2 }
 	)


### PR DESCRIPTION
## Симптом

В `data-raw-dump.json` у рецептов электролайзеров (`angels-electrolyser-1..4`) количества structure-components вдвое больше задуманных:

| Рецепт | Было (в dump) | Задумано |
|---|---|---|
| `angels-electrolyser`   | 2 basic-structure-components | **1** |
| `angels-electrolyser-2` | 4 intermediate-structure-components | **2** |
| `angels-electrolyser-3` | 16 intermediate-structure-components | **8** |
| `angels-electrolyser-4` | 4 advanced-structure-components | **2** |

После проверки нашлись ещё две аналогичные проблемы с `prev-tier` ингредиентами.

## Причина

`paralib.bobmods.lib.recipe.add_ingredient` (и `add_new_ingredient`) **суммирует** количество, если ингредиент уже есть в рецепте. Если один и тот же `(recipe, ingredient)` вызывается дважды — итог удваивается.

## Что найдено и пофикшено

### 1. `angels-electrolyser-1..4` + structure-components

`mods/zzzparanoidal/tweaks/recipe/insert-structured-components.lua` содержал идентичный блок `add_ingredient` для электролайзеров в **двух функциях**: `replaceMachine` (152-167) и `replaceAngelPetro` (440-455). Обе вызываются в конце файла.

**Фикс:** удалил блок из `replaceMachine` — электролайзеры концептуально petrochem, их место в `replaceAngelPetro`. Коммит `d346d1fa0`.

### 2. `angels-electric-boiler-2/-3` + prev-tier

В `mods/zzzparanoidal/final-fixes/recipies.lua` блок `remove_ingredient` + `add_new_ingredient` для boiler-2/3 **продублирован внутри одного файла** (строки 378-386 и 570-578, побайтово идентичны). Итог: 4× prev tier вместо 2×.

**Фикс:** удалил второй экземпляр (570-578). Коммит `0d4efe0e7`.

### 3. `angels-salination-plant-2` + `angels-salination-plant` ×2

`prev-tier` добавлялся одновременно в `recipies.lua:365` (канонический 2×-tier-scaling блок) и в `replaceMachine` (`insert-structured-components.lua:27-30`).

**Фикс:** убрал из `replaceMachine` — место для tier-scaling это `recipies.lua`, `replaceMachine` должен только structure-components добавлять. Коммит `0d4efe0e7`.

## Verification

Скан всех zzz lua-файлов на пары `(recipe, ingredient)` с >1 вызовом `add_ingredient/add_new_ingredient` после фикса возвращает 0 дублей.

В Lua-консоли после рестарта Factorio с этой веткой:

```lua
/c
for _, n in pairs({"angels-electrolyser","angels-electrolyser-2","angels-electrolyser-3","angels-electrolyser-4"}) do
  for _, ing in pairs(game.recipe_prototypes[n].ingredients) do
    if string.find(ing.name, "structure") then game.print(n.." → "..ing.name.." × "..ing.amount) end
  end
end
```
Ожидается: 1 / 2 / 8 / 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)