### PR TITLE
Чистит мёртвые ссылки на pipe-casting рецепты из 1.1

### DIFF
--- a/mods/zzzparanoidal/final-fixes/technologies.lua
+++ b/mods/zzzparanoidal/final-fixes/technologies.lua
@@ -93,9 +93,6 @@ paralib.bobmods.lib.tech.remove_prerequisite("angels-metallurgy-1", "bob-electri
 paralib.bobmods.lib.tech.remove_prerequisite("angels-nickel-smelting-1", "angels-ore-crushing")
 paralib.bobmods.lib.tech.remove_prerequisite("angels-lead-smelting-1", "angels-ore-crushing")
 paralib.bobmods.lib.tech.remove_prerequisite("angels-lead-smelting-1", "angels-basic-chemistry")
---убираем рецепты из технологий
-paralib.bobmods.lib.tech.remove_recipe_unlock("angels-stone-smelting-1", "angels-stone-pipe-casting")
-paralib.bobmods.lib.tech.remove_recipe_unlock("angels-stone-smelting-1", "angels-stone-pipe-to-ground-casting")
 --перенос электролиза дальше по дереву
 paralib.bobmods.lib.tech.remove_recipe_unlock("angels-basic-chemistry", "angels-electrolyser")
 paralib.bobmods.lib.tech.remove_recipe_unlock("angels-basic-chemistry", "angels-dirt-water-separation")
@@ -168,22 +165,6 @@ paralib.bobmods.lib.recipe.hide("bob-copper-tungsten-pipe")
 paralib.bobmods.lib.recipe.hide("bob-copper-tungsten-pipe-to-ground")
 paralib.bobmods.lib.recipe.hide("bob-tungsten-pipe")
 paralib.bobmods.lib.recipe.hide("bob-tungsten-pipe-to-ground")
-
-paralib.bobmods.lib.tech.remove_recipe_unlock(
-	"angels-copper-tungsten-smelting-1",
-	"angels-copper-tungsten-pipe-casting"
-)
-paralib.bobmods.lib.tech.remove_recipe_unlock(
-	"angels-copper-tungsten-smelting-1",
-	"angels-copper-tungsten-pipe-to-ground-casting"
-)
-paralib.bobmods.lib.tech.remove_recipe_unlock("bob-tungsten-alloy-processing", "angels-copper-tungsten-pipe-casting")
-paralib.bobmods.lib.tech.remove_recipe_unlock(
-	"bob-tungsten-alloy-processing",
-	"angels-copper-tungsten-pipe-to-ground-casting"
-)
-paralib.bobmods.lib.tech.remove_recipe_unlock("angels-tungsten-smelting-1", "angels-tungsten-pipe-casting")
-paralib.bobmods.lib.tech.remove_recipe_unlock("angels-tungsten-smelting-1", "angels-tungsten-pipe-to-ground-casting")
 
 --фикс недоступности исследования артиллерии
 paralib.bobmods.lib.tech.remove_prerequisite("artillery", "radar")
@@ -557,12 +538,8 @@ paralib.bobmods.lib.tech.add_recipe_unlock("angels-bio-processing-red", "Calcium
 --Рокировка рецептов нитинольных труб (AKMF)
 paralib.bobmods.lib.tech.add_recipe_unlock("angels-nitinol-smelting-1", "bob-nitinol-pipe")
 paralib.bobmods.lib.tech.remove_recipe_unlock("bob-nitinol-processing", "bob-nitinol-pipe")
-paralib.bobmods.lib.tech.remove_recipe_unlock("angels-nitinol-smelting-1", "angels-nitinol-pipe-casting")
-paralib.bobmods.lib.tech.add_recipe_unlock("bob-nitinol-processing", "angels-nitinol-pipe-casting")
 paralib.bobmods.lib.tech.add_recipe_unlock("angels-nitinol-smelting-1", "bob-nitinol-pipe-to-ground")
 paralib.bobmods.lib.tech.remove_recipe_unlock("bob-nitinol-processing", "bob-nitinol-pipe-to-ground")
-paralib.bobmods.lib.tech.remove_recipe_unlock("angels-nitinol-smelting-1", "angels-nitinol-pipe-to-ground-casting")
-paralib.bobmods.lib.tech.add_recipe_unlock("bob-nitinol-processing", "angels-nitinol-pipe-to-ground-casting")
 
 --Для сборщика электроники нужны фиол. манипуляторы (AKMF)
 paralib.bobmods.lib.tech.add_prerequisite("bob-electronics-machine-3", "bob-turbo-inserter")


### PR DESCRIPTION
## Контекст

В 1.1 в сборке был мод **`angels-smelting-extended`** (Pezzawinkle, v1.0.13, 1.1-only), который добавлял рецепты pipe-casting через molten metals:

- `angels-iron-pipe-casting`, `angels-copper-pipe-casting`, `angels-steel-pipe-casting`, ..., `angels-nitinol-pipe-casting`
- `angels-X-pipe-to-ground-casting` для каждого металла

В 2.0 мод не портирован, в сборку не добавлен. Bob-трубы в 2.0 (`bob-copper-pipe`, `bob-steel-pipe` и т.д.) используют классическую плитовую схему — без molten-fluid casting.

## Что чистим

`mods/zzzparanoidal/final-fixes/technologies.lua` содержал вызовы `tech.remove_recipe_unlock` и `tech.add_recipe_unlock` для несуществующих в 2.0 рецептов. Все они — no-op'ы.

Удалено:

| Металл | Файл:строки | Действие |
|---|---|---|
| stone | `technologies.lua:97-98` | 2 строки `remove_recipe_unlock` |
| copper-tungsten + tungsten | `technologies.lua:172-186` | 15 строк (5 `remove_recipe_unlock`) |
| nitinol | `technologies.lua:560-561, 564-565` | 4 строки из блока «Рокировка рецептов нитинольных труб» (`angels-nitinol-pipe-casting`/`-to-ground-casting`) |

Итого: **−23 строки**, 0 функциональных изменений.

## Что сохранено

Функциональная часть блока «Рокировка рецептов нитинольных труб» — строки для **`bob-nitinol-pipe`** / **`bob-nitinol-pipe-to-ground`**. Эти рецепты в 2.0 существуют (плитовая бобовская схема), и рокада с `bob-nitinol-processing` на `angels-nitinol-smelting-1` реально работает.

## Будущее

Если pipe-casting понадобится — портировать `angels-smelting-extended` отдельным PR'ом: ~20 рецептов + tech-юнлоки + балансовые цифры под 2.0. Сейчас не делаем, чтобы не мешать чистку с новой функциональностью.

🤖 Generated with [Claude Code](https://claude.com/claude-code)