### PR TITLE
Группирует все электрические столбы в Angels-подгруппах (closes #189)

### DIFF
--- a/mods/zzzparanoidal/data-final-fixes.lua
+++ b/mods/zzzparanoidal/data-final-fixes.lua
@@ -27,6 +27,7 @@ require("tweaks.entity.nuke-cliffs")
 require("tweaks.item.personal-roboport")
 require("tweaks.item.roboport")
 require("tweaks.item.fuel")
+require("tweaks.item.grouping")
 
 require("tweaks.recipe.insert-mining-drill-bit")
 require("tweaks.recipe.insert-structured-components")

--- a/mods/zzzparanoidal/tweaks/item/grouping.lua
+++ b/mods/zzzparanoidal/tweaks/item/grouping.lua
@@ -1,0 +1,79 @@
+-- Кастомная группировка items/recipes в Factoriopedia и инвентаре.
+-- Запускается в data-final-fixes, чтобы все сторонние моды успели объявить
+-- свои прототипы. Каждая секция ниже решает свою задачу и независима от
+-- других — при добавлении нового кейса просто вписать ещё один assign().
+
+local function assign(subgroup, entries)
+	-- Если целевая subgroup не определена (например, angelsindustries опционально
+	-- отсутствует и не создал angels-*-power-poles) — пропускаем тихо, чтобы не
+	-- ронять загрузку при assignID-валидации.
+	if not data.raw["item-subgroup"][subgroup] then return end
+	for _, entry in ipairs(entries) do
+		local name, order = entry[1], entry[2]
+		if data.raw.item[name] then
+			data.raw.item[name].subgroup = subgroup
+			data.raw.item[name].order = order
+		end
+		if data.raw.recipe[name] then
+			data.raw.recipe[name].subgroup = subgroup
+			data.raw.recipe[name].order = order
+		end
+	end
+end
+
+-- ============================================================
+-- Электрические столбы (issue #189).
+-- В 2.0 lighted-варианты (Lighted-Poles-Plus), bob's small-iron-electric-pole,
+-- bi-wooden-pole-*, bi-large-substation остались в ванильной energy-pipe-distribution,
+-- из-за чего «голые» столбы оказывались далеко от своих тиров. В 1.1 решал блок
+-- в prototypes/micro-final-fix.lua — восстанавливаем для 2.0.
+--
+-- Используем существующие angels-*-power-poles сабгруппы. Каждый lighted-вариант
+-- ставим сразу после своего родителя через суффикс order=-lit.
+-- ============================================================
+
+assign("angels-power-poles", {
+	{ "small-electric-pole",              "a" },
+	{ "lighted-small-electric-pole",      "a-lit" },
+	{ "small-iron-electric-pole",         "b" },
+	{ "lighted-small-iron-electric-pole", "b-lit" },
+	{ "bi-wooden-pole-big",               "c" },
+	{ "lighted-bi-wooden-pole-big",       "c-lit" },
+	{ "bi-wooden-pole-huge",              "d" },
+	{ "lighted-bi-wooden-pole-huge",      "d-lit" },
+})
+
+assign("angels-medium-power-poles", {
+	{ "medium-electric-pole",               "a" },
+	{ "lighted-medium-electric-pole",       "a-lit" },
+	{ "bob-medium-electric-pole-2",         "b" },
+	{ "lighted-bob-medium-electric-pole-2", "b-lit" },
+	{ "bob-medium-electric-pole-3",         "c" },
+	{ "lighted-bob-medium-electric-pole-3", "c-lit" },
+	{ "bob-medium-electric-pole-4",         "d" },
+	{ "lighted-bob-medium-electric-pole-4", "d-lit" },
+})
+
+assign("angels-big-power-poles", {
+	{ "big-electric-pole",               "a" },
+	{ "lighted-big-electric-pole",       "a-lit" },
+	{ "bob-big-electric-pole-2",         "b" },
+	{ "lighted-bob-big-electric-pole-2", "b-lit" },
+	{ "bob-big-electric-pole-3",         "c" },
+	{ "lighted-bob-big-electric-pole-3", "c-lit" },
+	{ "bob-big-electric-pole-4",         "d" },
+	{ "lighted-bob-big-electric-pole-4", "d-lit" },
+})
+
+assign("angels-sub-power-poles", {
+	{ "substation",                  "a" },
+	{ "lighted-substation",          "a-lit" },
+	{ "bob-substation-2",            "b" },
+	{ "lighted-bob-substation-2",    "b-lit" },
+	{ "bob-substation-3",            "c" },
+	{ "lighted-bob-substation-3",    "c-lit" },
+	{ "bob-substation-4",            "d" },
+	{ "lighted-bob-substation-4",    "d-lit" },
+	{ "bi-large-substation",         "e" },
+	{ "lighted-bi-large-substation", "e-lit" },
+})


### PR DESCRIPTION
Closes #189.

## Симптом

`small-iron-electric-pole` сидит далеко от остальных small-столбов, и все lighted-варианты (Lighted-Poles-Plus) отделены в `energy-pipe-distribution` вместо того, чтобы стоять рядом со своими bare-родителями.

## Причина

`angelsindustries/prototypes/ordening/angels-power.lua` в 2.0 перенёс ванильные + bob-tier столбы в подгруппы `angels-power-poles` / `angels-medium-power-poles` / `angels-big-power-poles` / `angels-sub-power-poles`. Но Angel ничего не знает про:

- **lighted-копии** от мода `Lighted-Poles-Plus` (Optera) — создаются динамически для каждого столба, остаются в дефолтной `energy-pipe-distribution`
- **bob's `small-iron-electric-pole`** — оставлен Бобом в `energy-pipe-distribution`
- **`bi-wooden-pole-big/huge`**, **`bi-large-substation`** от Bio Industries 2

В 1.1 это решалось руками в `mods/zzzparanoidal/prototypes/micro-final-fix.lua` — там был длинный блок, явно перетаскивающий каждый lighted-вариант в кастомные подгруппы (`wooden-pole` / `medium-electric-pole` / `big-electric-pole` / `substation`). При порте на 2.0 этот блок выпал.

## Решение

Восстанавливаем 1.1-подход с двумя поправками:

1. Переиспользуем существующие **Angels-подгруппы** (`angels-power-poles` etc.), а не создаём свои.
2. Каждый lighted-вариант ставим сразу после своего родителя через суффикс `order=-lit` — пары читаются естественно.

### Что переезжает (15 items + рецепты)

**В `angels-power-poles` (small / wooden tier)**:
- `lighted-small-electric-pole`, `small-iron-electric-pole`, `lighted-small-iron-electric-pole`, `bi-wooden-pole-big`, `lighted-bi-wooden-pole-big`, `bi-wooden-pole-huge`, `lighted-bi-wooden-pole-huge`

**В `angels-medium-power-poles`**: `lighted-medium-electric-pole`, `lighted-bob-medium-electric-pole-2/3/4`

**В `angels-big-power-poles`**: `lighted-big-electric-pole`, `lighted-bob-big-electric-pole-2/3/4`

**В `angels-sub-power-poles`**: `lighted-substation`, `lighted-bob-substation-2/3/4`, `bi-large-substation`, `lighted-bi-large-substation`

### Структура файла

`mods/zzzparanoidal/tweaks/item/grouping.lua` — **универсальный файл группировки на будущее**. Helper `assign(subgroup, pairs)` проставляет `subgroup` и `order` и для item, и для recipe (с if-guard на наличие). Текущая первая секция — «Электрические столбы». По мере необходимости туда же будут добавляться новые секции (генераторы, etc.) без оверхеда.

Регистрация — в `data-final-fixes.lua` (нужно после загрузки Lighted-Poles-Plus и Bio_Industries_2, чтобы их прототипы существовали).

<img width="389" height="505" alt="image" src="https://github.com/user-attachments/assets/46d4db6c-6097-46be-a91b-9ec876a87550" />