### PR TITLE
Возвращает marathon-баланс для steam-engine 2..5 (порт из 1.1)

### DIFF
--- a/mods/zzzparanoidal/final-fixes/recipies.lua
+++ b/mods/zzzparanoidal/final-fixes/recipies.lua
@@ -70,14 +70,40 @@ paralib.bobmods.lib.recipe.add_new_ingredient(
 	{ type = "item", name = "angels-storage-tank-3", amount = 4 }
 )
 
-paralib.bobmods.lib.recipe.remove_ingredient("bob-steam-engine-2", "steam-engine")
-paralib.bobmods.lib.recipe.add_new_ingredient("bob-steam-engine-2", { type = "item", name = "steam-engine", amount = 2 })
-paralib.bobmods.lib.recipe.remove_ingredient("bob-steam-engine-3", "bob-steam-engine-2")
-paralib.bobmods.lib.recipe.add_new_ingredient("bob-steam-engine-3", { type = "item", name = "bob-steam-engine-2", amount = 2 })
-paralib.bobmods.lib.recipe.remove_ingredient("bob-steam-engine-4", "bob-steam-engine-3")
-paralib.bobmods.lib.recipe.add_new_ingredient("bob-steam-engine-4", { type = "item", name = "bob-steam-engine-3", amount = 2 })
-paralib.bobmods.lib.recipe.remove_ingredient("bob-steam-engine-5", "bob-steam-engine-4")
-paralib.bobmods.lib.recipe.add_new_ingredient("bob-steam-engine-5", { type = "item", name = "bob-steam-engine-4", amount = 2 })
+-- Цены паровых двигателей по 1.1 marathon/recipe-bob-steam-power.lua (normal mode).
+-- В 2.0 marathon-мод не подтянули, default bobpower-рецепты в 5-15× дешевле, что
+-- разрушает прогрессию. set_ingredients ниже восстанавливает 1.1-баланс плюс
+-- структурные компоненты (basic/intermediate), которые в 1.1 добавлял KaoExtended.
+paralib.bobmods.lib.recipe.set_ingredients("bob-steam-engine-2", {
+	{ type = "item", name = "steam-engine",                   amount = 2 },
+	{ type = "item", name = "steel-plate",                    amount = 75 },
+	{ type = "item", name = "bob-steel-pipe",                 amount = 25 },
+	{ type = "item", name = "bob-steel-gear-wheel",           amount = 25 },
+	{ type = "item", name = "bob-steel-bearing",              amount = 15 },
+	{ type = "item", name = "basic-structure-components",     amount = 1 },
+})
+paralib.bobmods.lib.recipe.set_ingredients("bob-steam-engine-3", {
+	{ type = "item", name = "bob-steam-engine-2",                amount = 2 },
+	{ type = "item", name = "bob-brass-pipe",                    amount = 25 },
+	{ type = "item", name = "bob-brass-alloy",                   amount = 45 },
+	{ type = "item", name = "bob-cobalt-steel-gear-wheel",       amount = 25 },
+	{ type = "item", name = "bob-cobalt-steel-bearing",          amount = 15 },
+	{ type = "item", name = "intermediate-structure-components", amount = 1 },
+})
+paralib.bobmods.lib.recipe.set_ingredients("bob-steam-engine-4", {
+	{ type = "item", name = "bob-steam-engine-3",       amount = 2 },
+	{ type = "item", name = "bob-titanium-pipe",        amount = 25 },
+	{ type = "item", name = "bob-titanium-plate",       amount = 40 },
+	{ type = "item", name = "bob-titanium-gear-wheel",  amount = 25 },
+	{ type = "item", name = "bob-titanium-bearing",     amount = 20 },
+})
+paralib.bobmods.lib.recipe.set_ingredients("bob-steam-engine-5", {
+	{ type = "item", name = "bob-steam-engine-4",      amount = 2 },
+	{ type = "item", name = "bob-nitinol-pipe",        amount = 25 },
+	{ type = "item", name = "bob-nitinol-alloy",       amount = 40 },
+	{ type = "item", name = "bob-nitinol-gear-wheel",  amount = 25 },
+	{ type = "item", name = "bob-nitinol-bearing",     amount = 20 },
+})
 
 paralib.bobmods.lib.recipe.remove_ingredient("bob-boiler-2", "boiler")
 paralib.bobmods.lib.recipe.add_new_ingredient("bob-boiler-2", { type = "item", name = "boiler", amount = 2 })

--- a/mods/zzzparanoidal/tweaks/recipe/insert-structured-components.lua
+++ b/mods/zzzparanoidal/tweaks/recipe/insert-structured-components.lua
@@ -221,14 +221,8 @@ local function replaceMining()
 	)
 end
 local function replacePower()
-	paralib.bobmods.lib.recipe.add_ingredient(
-		"bob-steam-engine-2",
-		{ type = "item", name = "basic-structure-components", amount = 1 }
-	)
-	paralib.bobmods.lib.recipe.add_ingredient(
-		"bob-steam-engine-3",
-		{ type = "item", name = "intermediate-structure-components", amount = 1 }
-	)
+	-- bob-steam-engine-2/3 structure-components включены в set_ingredients
+	-- в final-fixes/recipies.lua (часть marathon 1.1-баланса).
 
 	if data.raw["item"]["petroleum-generator"] then
 		paralib.bobmods.lib.recipe.add_ingredient(


### PR DESCRIPTION
## Контекст

В 1.1 модпак включал mod **`marathon`** (Benoit Girard & Afforess, v9.1.17), который через `marathon/prototypes/recipe-bob-steam-power.lua` полностью переопределял рецепты `steam-engine-2..5` в значительно более дорогие тиры.

В 2.0 marathon не порт ирован. SKProCH при VOLBAX2-синхронизации (коммит `9c2503acb`) сохранил только **2× каскад** (`prev tier`), но материальные цифры (plate, pipe, gear-wheel, bearing) остались дефолтные bobpower (5 каждого) — в **5-15× дешевле 1.1**. Это разрушает прогрессию мид-гейма: tier-5 steam-engine получается с 16 базовых паровиков + всего ~20 стальных предметов, при том что в 1.1 это были сотни.

## Что чинит PR

Восстанавливает 1.1 normal-mode значения из marathon-source, плюс `basic/intermediate-structure-components` (которые в 1.1 шли через KaoExtended поверх marathon).

| Тир | Ингредиенты |
|---|---|
| `bob-steam-engine-2` | 2× steam-engine + 75 steel-plate + 25 steel-pipe + 25 steel-gear + 15 steel-bearing + 1 basic-struct |
| `bob-steam-engine-3` | 2× prev + 25 brass-pipe + 45 brass-alloy + 25 cobalt-steel-gear + 15 cobalt-steel-bearing + 1 intermediate-struct |
| `bob-steam-engine-4` | 2× prev + 25 titanium-pipe + 40 titanium-plate + 25 titanium-gear + 20 titanium-bearing |
| `bob-steam-engine-5` | 2× prev + 25 nitinol-pipe + 40 nitinol-alloy + 25 nitinol-gear + 20 nitinol-bearing |

## Изменения

- **`mods/zzzparanoidal/final-fixes/recipies.lua`**: lines 73-80 (старый 2× cascade override без material part) заменены на `set_ingredients` блок с полным набором ингредиентов из marathon 1.1.
- **`mods/zzzparanoidal/tweaks/recipe/insert-structured-components.lua`**: удалены избыточные `add_ingredient` для bob-steam-engine-2/3 — теперь structure-components включены прямо в `set_ingredients`, без зависимости от порядка выполнения файлов в data-final-fixes.

## Не трогаем в этом PR

- **`steam-turbine`, `bob-steam-turbine-2/3`** — отдельные скриншоты не были показаны, в этом PR не меняем. Там 2× каскад без material override тоже остался от VOLBAX2.
- **`bob-boiler-2..5`** — уже исправлены в `recipies.lua:732-751` (`set_ingredients` с 1.1-цифрами из `zzz/micro-final-fix.lua`).
- **Accumulators / solar-panel** — отдельные семьи, не в текущей задаче.

🤖 Generated with [Claude Code](https://claude.com/claude-code)