### PR TITLE
Удаление ультимативной для старта ветровой турбины

### DIFF
--- a/mods/zzzparanoidal/final-fixes/recipies.lua
+++ b/mods/zzzparanoidal/final-fixes/recipies.lua
@@ -70,14 +70,40 @@ paralib.bobmods.lib.recipe.add_new_ingredient(
 	{ type = "item", name = "angels-storage-tank-3", amount = 4 }
 )
 
-paralib.bobmods.lib.recipe.remove_ingredient("bob-steam-engine-2", "steam-engine")
-paralib.bobmods.lib.recipe.add_new_ingredient("bob-steam-engine-2", { type = "item", name = "steam-engine", amount = 2 })
-paralib.bobmods.lib.recipe.remove_ingredient("bob-steam-engine-3", "bob-steam-engine-2")
-paralib.bobmods.lib.recipe.add_new_ingredient("bob-steam-engine-3", { type = "item", name = "bob-steam-engine-2", amount = 2 })
-paralib.bobmods.lib.recipe.remove_ingredient("bob-steam-engine-4", "bob-steam-engine-3")
-paralib.bobmods.lib.recipe.add_new_ingredient("bob-steam-engine-4", { type = "item", name = "bob-steam-engine-3", amount = 2 })
-paralib.bobmods.lib.recipe.remove_ingredient("bob-steam-engine-5", "bob-steam-engine-4")
-paralib.bobmods.lib.recipe.add_new_ingredient("bob-steam-engine-5", { type = "item", name = "bob-steam-engine-4", amount = 2 })
+-- Цены паровых двигателей по 1.1 marathon/recipe-bob-steam-power.lua (normal mode).
+-- В 2.0 marathon-мод не подтянули, default bobpower-рецепты в 5-15× дешевле, что
+-- разрушает прогрессию. set_ingredients ниже восстанавливает 1.1-баланс плюс
+-- структурные компоненты (basic/intermediate), которые в 1.1 добавлял KaoExtended.
+paralib.bobmods.lib.recipe.set_ingredients("bob-steam-engine-2", {
+	{ type = "item", name = "steam-engine",                   amount = 2 },
+	{ type = "item", name = "steel-plate",                    amount = 75 },
+	{ type = "item", name = "bob-steel-pipe",                 amount = 25 },
+	{ type = "item", name = "bob-steel-gear-wheel",           amount = 25 },
+	{ type = "item", name = "bob-steel-bearing",              amount = 15 },
+	{ type = "item", name = "basic-structure-components",     amount = 1 },
+})
+paralib.bobmods.lib.recipe.set_ingredients("bob-steam-engine-3", {
+	{ type = "item", name = "bob-steam-engine-2",                amount = 2 },
+	{ type = "item", name = "bob-brass-pipe",                    amount = 25 },
+	{ type = "item", name = "bob-brass-alloy",                   amount = 45 },
+	{ type = "item", name = "bob-cobalt-steel-gear-wheel",       amount = 25 },
+	{ type = "item", name = "bob-cobalt-steel-bearing",          amount = 15 },
+	{ type = "item", name = "intermediate-structure-components", amount = 1 },
+})
+paralib.bobmods.lib.recipe.set_ingredients("bob-steam-engine-4", {
+	{ type = "item", name = "bob-steam-engine-3",       amount = 2 },
+	{ type = "item", name = "bob-titanium-pipe",        amount = 25 },
+	{ type = "item", name = "bob-titanium-plate",       amount = 40 },
+	{ type = "item", name = "bob-titanium-gear-wheel",  amount = 25 },
+	{ type = "item", name = "bob-titanium-bearing",     amount = 20 },
+})
+paralib.bobmods.lib.recipe.set_ingredients("bob-steam-engine-5", {
+	{ type = "item", name = "bob-steam-engine-4",      amount = 2 },
+	{ type = "item", name = "bob-nitinol-pipe",        amount = 25 },
+	{ type = "item", name = "bob-nitinol-alloy",       amount = 40 },
+	{ type = "item", name = "bob-nitinol-gear-wheel",  amount = 25 },
+	{ type = "item", name = "bob-nitinol-bearing",     amount = 20 },
+})
 
 paralib.bobmods.lib.recipe.remove_ingredient("bob-boiler-2", "boiler")
 paralib.bobmods.lib.recipe.add_new_ingredient("bob-boiler-2", { type = "item", name = "boiler", amount = 2 })

--- a/mods/zzzparanoidal/final-fixes/recipies.lua
+++ b/mods/zzzparanoidal/final-fixes/recipies.lua
@@ -593,17 +593,6 @@ paralib.bobmods.lib.recipe.add_new_ingredient(
 	{ type = "item", name = "angels-chemical-plant-3", amount = 2 }
 )
 
-paralib.bobmods.lib.recipe.remove_ingredient("angels-electric-boiler-2", "angels-electric-boiler")
-paralib.bobmods.lib.recipe.add_new_ingredient(
-	"angels-electric-boiler-2",
-	{ type = "item", name = "angels-electric-boiler", amount = 2 }
-)
-paralib.bobmods.lib.recipe.remove_ingredient("angels-electric-boiler-3", "angels-electric-boiler-2")
-paralib.bobmods.lib.recipe.add_new_ingredient(
-	"angels-electric-boiler-3",
-	{ type = "item", name = "angels-electric-boiler-2", amount = 2 }
-)
-
 paralib.bobmods.lib.recipe.remove_ingredient("clowns-sluicer-2", "clowns-sluicer")
 paralib.bobmods.lib.recipe.add_new_ingredient("clowns-sluicer-2", { type = "item", name = "clowns-sluicer", amount = 2 })
 

--- a/mods/zzzparanoidal/final-fixes/recipies.lua
+++ b/mods/zzzparanoidal/final-fixes/recipies.lua
@@ -70,40 +70,14 @@ paralib.bobmods.lib.recipe.add_new_ingredient(
 	{ type = "item", name = "angels-storage-tank-3", amount = 4 }
 )
 
--- Цены паровых двигателей по 1.1 marathon/recipe-bob-steam-power.lua (normal mode).
--- В 2.0 marathon-мод не подтянули, default bobpower-рецепты в 5-15× дешевле, что
--- разрушает прогрессию. set_ingredients ниже восстанавливает 1.1-баланс плюс
--- структурные компоненты (basic/intermediate), которые в 1.1 добавлял KaoExtended.
-paralib.bobmods.lib.recipe.set_ingredients("bob-steam-engine-2", {
-	{ type = "item", name = "steam-engine",                   amount = 2 },
-	{ type = "item", name = "steel-plate",                    amount = 75 },
-	{ type = "item", name = "bob-steel-pipe",                 amount = 25 },
-	{ type = "item", name = "bob-steel-gear-wheel",           amount = 25 },
-	{ type = "item", name = "bob-steel-bearing",              amount = 15 },
-	{ type = "item", name = "basic-structure-components",     amount = 1 },
-})
-paralib.bobmods.lib.recipe.set_ingredients("bob-steam-engine-3", {
-	{ type = "item", name = "bob-steam-engine-2",                amount = 2 },
-	{ type = "item", name = "bob-brass-pipe",                    amount = 25 },
-	{ type = "item", name = "bob-brass-alloy",                   amount = 45 },
-	{ type = "item", name = "bob-cobalt-steel-gear-wheel",       amount = 25 },
-	{ type = "item", name = "bob-cobalt-steel-bearing",          amount = 15 },
-	{ type = "item", name = "intermediate-structure-components", amount = 1 },
-})
-paralib.bobmods.lib.recipe.set_ingredients("bob-steam-engine-4", {
-	{ type = "item", name = "bob-steam-engine-3",       amount = 2 },
-	{ type = "item", name = "bob-titanium-pipe",        amount = 25 },
-	{ type = "item", name = "bob-titanium-plate",       amount = 40 },
-	{ type = "item", name = "bob-titanium-gear-wheel",  amount = 25 },
-	{ type = "item", name = "bob-titanium-bearing",     amount = 20 },
-})
-paralib.bobmods.lib.recipe.set_ingredients("bob-steam-engine-5", {
-	{ type = "item", name = "bob-steam-engine-4",      amount = 2 },
-	{ type = "item", name = "bob-nitinol-pipe",        amount = 25 },
-	{ type = "item", name = "bob-nitinol-alloy",       amount = 40 },
-	{ type = "item", name = "bob-nitinol-gear-wheel",  amount = 25 },
-	{ type = "item", name = "bob-nitinol-bearing",     amount = 20 },
-})
+paralib.bobmods.lib.recipe.remove_ingredient("bob-steam-engine-2", "steam-engine")
+paralib.bobmods.lib.recipe.add_new_ingredient("bob-steam-engine-2", { type = "item", name = "steam-engine", amount = 2 })
+paralib.bobmods.lib.recipe.remove_ingredient("bob-steam-engine-3", "bob-steam-engine-2")
+paralib.bobmods.lib.recipe.add_new_ingredient("bob-steam-engine-3", { type = "item", name = "bob-steam-engine-2", amount = 2 })
+paralib.bobmods.lib.recipe.remove_ingredient("bob-steam-engine-4", "bob-steam-engine-3")
+paralib.bobmods.lib.recipe.add_new_ingredient("bob-steam-engine-4", { type = "item", name = "bob-steam-engine-3", amount = 2 })
+paralib.bobmods.lib.recipe.remove_ingredient("bob-steam-engine-5", "bob-steam-engine-4")
+paralib.bobmods.lib.recipe.add_new_ingredient("bob-steam-engine-5", { type = "item", name = "bob-steam-engine-4", amount = 2 })
 
 paralib.bobmods.lib.recipe.remove_ingredient("bob-boiler-2", "boiler")
 paralib.bobmods.lib.recipe.add_new_ingredient("bob-boiler-2", { type = "item", name = "boiler", amount = 2 })
@@ -593,6 +567,17 @@ paralib.bobmods.lib.recipe.add_new_ingredient(
 	{ type = "item", name = "angels-chemical-plant-3", amount = 2 }
 )
 
+paralib.bobmods.lib.recipe.remove_ingredient("angels-electric-boiler-2", "angels-electric-boiler")
+paralib.bobmods.lib.recipe.add_new_ingredient(
+	"angels-electric-boiler-2",
+	{ type = "item", name = "angels-electric-boiler", amount = 2 }
+)
+paralib.bobmods.lib.recipe.remove_ingredient("angels-electric-boiler-3", "angels-electric-boiler-2")
+paralib.bobmods.lib.recipe.add_new_ingredient(
+	"angels-electric-boiler-3",
+	{ type = "item", name = "angels-electric-boiler-2", amount = 2 }
+)
+
 paralib.bobmods.lib.recipe.remove_ingredient("clowns-sluicer-2", "clowns-sluicer")
 paralib.bobmods.lib.recipe.add_new_ingredient("clowns-sluicer-2", { type = "item", name = "clowns-sluicer", amount = 2 })
 
@@ -833,3 +818,5 @@ if data.raw.recipe["concrete"] and data.raw.item["angels-solid-sand"] then
 		data.raw.item["sand"].hidden = true
 	end
 end
+
+paralib.bobmods.lib.recipe.enabled("wind-turbine-2", false)


### PR DESCRIPTION
Удаление ультимативной для старта ветровой турбины (почти бесплатна и дает достаточно много энергии).

В моде есть еще ветро-турбины, которых не было в 1.1, но они хотя бы открываются колбами. Первая открывается после стали и дает около 300 киловатт. Вопрос нужно ли их как то нерфить пока не ясен.