### PR TITLE
Возвращает Oberhaul refining-патчи из 1.1 (sulfuric-acid + slag-байпродукт)

### DIFF
--- a/mods/zzzparanoidal/data-final-fixes.lua
+++ b/mods/zzzparanoidal/data-final-fixes.lua
@@ -109,5 +109,8 @@ for _, name in ipairs({ "angels-ore5-smelting", "angels-ore6-smelting" }) do
     end
 end
 
+-- Oberhaul refining-port (после OV.execute, чтобы OV не перезатёр изменения).
+require("tweaks.recipe.oberhaul-refining-port")
+
 --должно быть последним. После всех рецептов.
 require("tweaks.custom.flowfix")

--- a/mods/zzzparanoidal/tweaks/recipe/oberhaul-refining-port.lua
+++ b/mods/zzzparanoidal/tweaks/recipe/oberhaul-refining-port.lua
@@ -1,0 +1,58 @@
+-- Частичный порт Oberhaul (1.1-only, не портирован в 2.0):
+-- mods/Oberhaul/prototypes/angelssmelting.lua. Без этих патчей slag в 2.0
+-- добывается только через ore-sorting (4-8 crushed → 1 slag), весь stone-
+-- crushed уходит в slag-slurry → mineral-sludge → caustic catalyst дефицит.
+
+require("__zzzparanoidal__.paralib")
+
+-- 1) slag-processing-dissolution: серная кислота 15 → 25.
+-- Прямой data.raw вместо paralib.set_ingredient — последний внутри boblibrary
+-- использует item.result() для fluid, что портит структуру и рецепт перестаёт
+-- помещаться в Liquefier. Имя кислоты после Angels data-updates —
+-- angels-liquid-sulfuric-acid (vanilla-имя матчим тоже для безопасности).
+do
+	local r = data.raw.recipe["angels-slag-processing-dissolution"]
+	if r and r.ingredients then
+		for _, ing in ipairs(r.ingredients) do
+			if ing.name == "angels-liquid-sulfuric-acid" or ing.name == "sulfuric-acid" then
+				ing.amount = 25
+			end
+		end
+	end
+end
+
+-- 2) Slag как побочный продукт ore-processing рецептов (probability 0.1-0.6).
+-- В 1.1 это был основной источник slag, в 2.0 потеряно. Probability — из Oberhaul.
+-- Платина выпадает из шаблона angels-processed-<metal>: её рецепт назван
+-- angels-platinum-ore-processing, а angels-processed-platinum — это item.
+local slag_byproducts = {
+	{ metal = "iron",      probability = 0.6 },
+	{ metal = "copper",    probability = 0.6 },
+	{ metal = "lead",      probability = 0.5 },
+	{ metal = "tin",       probability = 0.5 },
+	{ metal = "aluminium", probability = 0.3 },
+	{ metal = "chrome",    probability = 0.3 },
+	{ metal = "manganese", probability = 0.3 },
+	{ metal = "nickel",    probability = 0.3 },
+	{ metal = "silica",    probability = 0.3 },
+	{ metal = "zinc",      probability = 0.3 },
+	{ metal = "gold",      probability = 0.2 },
+	{ metal = "silver",    probability = 0.2 },
+	{ metal = "titanium",  probability = 0.2 },
+	{ metal = "platinum",  probability = 0.1, recipe = "angels-platinum-ore-processing" },
+	{ metal = "tungsten",  probability = 0.1 },
+}
+
+for _, b in ipairs(slag_byproducts) do
+	local recipe_name = b.recipe or ("angels-processed-" .. b.metal)
+	local main_item = "angels-processed-" .. b.metal
+	if data.raw.recipe[recipe_name] then
+		paralib.bobmods.lib.recipe.add_result(recipe_name, {
+			type = "item",
+			name = "angels-slag",
+			amount = 1,
+			probability = b.probability,
+		})
+		data.raw.recipe[recipe_name].main_product = main_item
+	end
+end


### PR DESCRIPTION
## Summary

Частичный порт мода **Oberhaul** (Ober3550's BobsAngels Overhaul, 1.1-only, не портирован в 2.0). Восстанавливает 2 балансовых патча из `mods/Oberhaul/prototypes/angelssmelting.lua` (1.1), потерянные при порте 1.1 → 2.0.

### Что починили

**1) Серная кислота в `angels-slag-processing-dissolution`: 15 → 25.**
Oberhaul бампил расход сульфурки в 1.1 (видно по комментарию `--DrD 15` в его коде). После порта в 2.0 vanilla-значение 15 вернулось, slag-slurry стал «слишком дёшев» по кислоте.

**2) Slag как побочный продукт 15 рецептов `angels-processed-<metal>`** (probability 0.1..0.6, чем «жирнее» руда — тем выше шанс):

| Метал | probability | Метал | probability | Метал | probability |
|---|---|---|---|---|---|
| iron | 0.6 | manganese | 0.3 | gold | 0.2 |
| copper | 0.6 | nickel | 0.3 | silver | 0.2 |
| lead | 0.5 | silica | 0.3 | titanium | 0.2 |
| tin | 0.5 | zinc | 0.3 | platinum | 0.1 |
| aluminium | 0.3 | chrome | 0.3 | tungsten | 0.1 |

Это **основной источник slag в 1.1** — без него вся slag-цепочка (slag → slag-slurry → mineral-sludge → catalysator-brown) идёт через `stone-crushed-dissolution`, что выжигает камень и через каскад приводит к дефициту T1/T2 catalyst (юзер-репорт: «весь камень уходит на mineral-sludge», «T2 catalyst почти не получается»).

### Технические нюансы переноса

- В 2.0 рецепты переименованы с префиксом `angels-`, имена айтемов тоже (`slag → angels-slag`, `iron-ore-processing → angels-processed-iron`, `silica → silica` в названии рецепта но в Lua-коде ищется `angels-processed-silica`, и т.д.) — учтено в патче.
- Vanilla `sulfuric-acid` после Angels `data-updates` становится `angels-liquid-sulfuric-acid` (видно в factorio-current.log при дебаге) — матчу оба имени на всякий случай.
- **Прямой `data.raw.recipe[...]` патч amount вместо `paralib.set_ingredient`** — последний внутри boblibrary использует `item.result()` для подмены fluid-ингредиента, что портит структуру: рецепт перестаёт «помещаться» в Liquefier («Не может быть сделано в этой машине», см. факт из QA-цикла). Прямой in-place патч amount сохраняет всю метадату.
- `require("tweaks.recipe.oberhaul-refining-port")` подключён в `data-final-fixes.lua` **ПОСЛЕ** `angelsmods.functions.OV.execute()` — иначе OV-патчи Angels могут перезатереть результат (аналогично существующему блоку `patch_crushed_smelting`).