### PR TITLE
Симметричные боковые pipe-stub'ы на strand-casting-machine MK1..4

### DIFF
--- a/mods/zzzparanoidal/tweaks/recipe/angels-wire-coil-insulated-port.lua
+++ b/mods/zzzparanoidal/tweaks/recipe/angels-wire-coil-insulated-port.lua
@@ -1,24 +1,10 @@
--- Port angels-wire-coil-insulated из 1.1 angels-smelting-extended
--- (shielding.lua:140-208 + items/compression-extended.lua:62-73).
---
--- В 1.1 блок гейтился `if data.raw.item["insulated-cable"] then`. В 2.0 item
--- переименован в `bob-insulated-cable` → гейт возвращал nil, блок терялся.
--- Здесь восстанавливаем с 2.0-именами:
---   insulated-cable → bob-insulated-cable
---   liquid-rubber → angels-liquid-rubber
---   liquid-molten-X → angels-liquid-molten-X
---   liquid-coolant[-used] → angels-liquid-coolant[-used]
---   strand-casting-2/3 → angels-strand-casting-2/3
---   rubber tech → angels-rubbers
+-- 1.1 source: angels-smelting-extended/prototypes/recipes/shielding.lua:140-208
+-- + items/compression-extended.lua:62-73.
 
 if not data.raw.item["bob-insulated-cable"] then return end
--- Также гейт на angels-rubbers tech — подтверждает что Angels chain
--- загружен (нужна и теха для unlock, и категории angels-strand-casting-N,
--- и fluid angels-liquid-rubber). Без неё OV.add_unlock крашнется на nil.
 if not data.raw.technology["angels-rubbers"] then return end
 
--- count рассчитывается из native bob-insulated-cable recipe (ingredient[1].amount × 8).
--- Default 16 если parsing не удался.
+-- 1.1 формула: count = ingredient[1] нативного bob-insulated-cable × 8.
 local count = 16
 local native = data.raw.recipe["bob-insulated-cable"]
 if native and native.ingredients and native.ingredients[1] then
@@ -27,7 +13,6 @@ if native and native.ingredients and native.ingredients[1] then
 	if amt then count = amt * 8 end
 end
 
--- Item
 data:extend({
 	{
 		type = "item",
@@ -41,14 +26,9 @@ data:extend({
 	},
 })
 
--- Converting category: 1.1 использовала "electronics" если bobelectronics
--- загружен, иначе "crafting". В 2.0 bobelectronics всегда есть в paranoidal —
--- но guard на всякий случай.
 local converting_category = mods["bobelectronics"] and "electronics" or "crafting"
 
--- Recipes
 data:extend({
-	-- T2 casting: rubber + tin + copper + water → coils
 	{
 		type = "recipe",
 		name = "angels-wire-coil-insulated-casting",
@@ -67,7 +47,6 @@ data:extend({
 			{ type = "item", name = "angels-wire-coil-insulated", amount = count },
 		},
 	},
-	-- T3 fast: rubber + tin + copper + coolant → coils × 2 + used coolant
 	{
 		type = "recipe",
 		name = "angels-wire-coil-insulated-casting-fast",
@@ -88,7 +67,6 @@ data:extend({
 		},
 		main_product = "angels-wire-coil-insulated",
 	},
-	-- Converting: 4 coils → 20 insulated-cable (выгоднее vanilla 1:1)
 	{
 		type = "recipe",
 		name = "angels-wire-coil-insulated-converting",
@@ -107,20 +85,23 @@ data:extend({
 	},
 })
 
--- Tech unlocks на angels-rubbers (1.1 использовал "rubber", в 2.0 — angels-rubbers)
+-- 1.1 unlock'ил эти recipes через тех "rubber"; в 2.0 он переименован в "angels-rubbers".
 local OV = angelsmods.functions.OV
 OV.add_unlock("angels-rubbers", "angels-wire-coil-insulated-casting")
 OV.add_unlock("angels-rubbers", "angels-wire-coil-insulated-casting-fast")
 OV.add_unlock("angels-rubbers", "angels-wire-coil-insulated-converting")
 
--- 4-й fluid input для liquid-rubber на strand-casting-machine MK1..4.
--- Default — 3 input + 1 output. Добавляем боковой box на east side.
+-- 4-й fluid input на strand-casting-machine MK1..4. Одинаковая раскладка на
+-- всех тирах — upgrade'ы не сдвигают pipe-positions. Position x=±2 = граница
+-- bounding_box 5×5 (в 2.0 position обязан быть внутри; в 1.1 было ±3).
 local extra_box = {
 	production_type = "input",
 	pipe_covers = pipecoverspictures(),
 	volume = 1000,
-	filter = "angels-liquid-rubber",
-	pipe_connections = { { flow_direction = "input", position = { 2, 1 }, direction = defines.direction.east } },
+	pipe_connections = {
+		{ flow_direction = "input-output", position = { -2, 1 }, direction = defines.direction.west },
+		{ flow_direction = "input-output", position = {  2, 1 }, direction = defines.direction.east },
+	},
 }
 for _, name in ipairs({
 	"angels-strand-casting-machine",


### PR DESCRIPTION
Фикс к PR #246 (angels-wire-coil-insulated).

## Проблема

В PR #246 был добавлен 4-й fluid input на `strand-casting-machine` MK1..4:
- одна `input`-only pipe_connection
- позиция `(2, 1)` — только на восточной стороне
- `filter = "angels-liquid-rubber"` (привязка к одной жидкости)

Раскладка получилась **несимметричной** (pipe-stub только справа) и жёсткой — pipe только в одну сторону, фильтровался только под rubber.

## Что меняется

`mods/zzzparanoidal/tweaks/recipe/angels-wire-coil-insulated-port.lua` — секция `extra_box`:

| Параметр | Было | Стало |
|---|---|---|
| `pipe_connections` | 1 connection: `input` на `(2, 1)` east | 2 connections: `input-output` на `(-2, 1)` west + `(2, 1)` east |
| `flow_direction` | `input` | `input-output` |
| `filter` | `"angels-liquid-rubber"` | удалён |

Раскладка повторяет 1.1 ASE — `(-3, 1)` + `(3, 1)`, обрезанные до `±2` (2.0 position обязан быть в bounding_box).

До/После. Прямо симметрично сделать не получилось из-за другого мода, который рулит выходами.

<img width="300" height="300" alt="Снимок экрана 2026-05-27 в 15 57 28" src="https://github.com/user-attachments/assets/bb8f8f89-8e35-4a78-ab74-53092c8c8265" />

<img width="300" height="300" alt="Снимок экрана 2026-05-27 в 15 55 53" src="https://github.com/user-attachments/assets/0eb0b6d7-85f2-4c34-a392-1457f9964d28" />


