### PR TITLE
Печи для сплавов: рецепты как в 1.1 (Oberhaul/KaoExtended)

### DIFF
--- a/mods/zzzparanoidal/final-fixes/recipies.lua
+++ b/mods/zzzparanoidal/final-fixes/recipies.lua
@@ -767,12 +767,21 @@ if data.raw.recipe["hs_holo_sign"] then
 	paralib.bobmods.lib.tech.add_recipe_unlock("circuit-network", "hs_holo_sign")
 end
 
---Убрана левая печь из электо печи для сплавов (AKMF)
+-- Печи для сплавов: вшиваем базовую печь как в 1.1 (Oberhaul beltrecipes.lua:154-173).
+paralib.bobmods.lib.recipe.set_ingredients("bob-stone-mixing-furnace", {
+	{ type = "item", name = "stone-furnace", amount = 1 },
+	{ type = "item", name = "stone-brick", amount = 5 },
+})
+paralib.bobmods.lib.recipe.set_ingredients("bob-steel-mixing-furnace", {
+	{ type = "item", name = "steel-furnace", amount = 1 },
+	{ type = "item", name = "steel-plate", amount = 10 },
+	{ type = "item", name = "stone-brick", amount = 10 },
+})
+-- electric-mixing: chemical-furnace (от insert-structured-components) → electric-furnace (1.1).
 paralib.bobmods.lib.recipe.remove_ingredient("bob-electric-mixing-furnace", "bob-electric-chemical-furnace")
-paralib.bobmods.lib.recipe.add_ingredient(
-	"bob-electric-mixing-furnace",
-	{ type = "item", name = "electric-furnace", amount = 1 }
-)
+paralib.bobmods.lib.recipe.add_ingredient("bob-electric-mixing-furnace", { type = "item", name = "electric-furnace", amount = 1 })
+-- electric-chemical-mixing: electric-furnace → electric-mixing-furnace (1.1).
+paralib.bobmods.lib.recipe.replace_ingredient("bob-electric-chemical-mixing-furnace", "electric-furnace", "bob-electric-mixing-furnace")
 
 -- Unlock iron-stick by default
 paralib.bobmods.lib.recipe.enabled("iron-stick", true)

--- a/mods/zzzparanoidal/tweaks/recipe/insert-structured-components.lua
+++ b/mods/zzzparanoidal/tweaks/recipe/insert-structured-components.lua
@@ -125,9 +125,6 @@ local function replaceMachine()
 		{ type = "item", name = "advanced-structure-components", amount = 2 }
 	)
 
-	paralib.bobmods.lib.recipe.add_ingredient("steel-furnace", { type = "item", name = "stone-furnace", amount = 2 })
-	paralib.bobmods.lib.recipe.add_ingredient("electric-furnace", { type = "item", name = "steel-furnace", amount = 2 })
-
 	paralib.bobmods.lib.recipe.add_ingredient(
 		"electric-furnace",
 		{ type = "item", name = "basic-structure-components", amount = 1 }


### PR DESCRIPTION
Часть баланса печей для сплавов не перенеслась из 1.1 при порте.

### `mods/zzzparanoidal/final-fixes/recipies.lua`

| печь (имя в игре) | было (2.0) | стало (1.1) |
|---|---|---|
| `bob-stone-mixing-furnace` (Stone filtering furnace) | `stone ×5` | `stone-furnace ×1 + stone-brick ×5` |
| `bob-steel-mixing-furnace` (Steel filtering furnace) | `steel ×6 + stone-brick ×10` | `steel-furnace ×1 + steel ×10 + stone-brick ×10` |
| `bob-electric-mixing-furnace` (Electric filtering furnace 1) | `… + bob-electric-chemical-furnace ×2` | `… + electric-furnace ×1` |
| `bob-electric-chemical-mixing-furnace` (Electric filtering furnace 2) | вшита `electric-furnace ×1` | вшита `bob-electric-mixing-furnace ×1` |
| `electric-furnace` | `steel-furnace ×3` | `steel-furnace ×1` |

### `mods/zzzparanoidal/tweaks/recipe/insert-structured-components.lua`
- удалён `add_ingredient("electric-furnace", steel-furnace ×2)` — aai-2.0 уже кладёт `steel-furnace ×1`, а этот add прибавлял ещё 2 → 3 (в 1.1 `KaoExtended.addtorecipe` был идемпотентным, `add_ingredient` прибавляет).
- удалён `add_ingredient("steel-furnace", stone-furnace ×2)` — мёртвый no-op (затирается `marathon-port` через `set_ingredients`).

### Открытый вопрос
В 2.0 в рецепте `electric-furnace` появился `concrete ×5` (от aai-industry; в 1.1 их aai-блок был закомментирован, бетона не было). Оставляем как есть или возвращаем к 1.1?

🤖 Generated with [Claude Code](https://claude.com/claude-code)