### PR TITLE
toxicPollution2: фикс урона в remote view (мод не видел броню)

### DIFF
--- a/mods/toxicPollution2/classes/toxic.lua
+++ b/mods/toxicPollution2/classes/toxic.lua
@@ -167,11 +167,18 @@ function Toxic:RemoveAlert(player, signal)
 end
 
 function Toxic:GetPollution(player)
-    return math.floor(player.surface.get_pollution({player.position.x, player.position.y}))
+    -- Read at the character, not player.position: in remote view the latter is the camera.
+    local c = player.character
+    if not c then return 0 end
+    return math.floor(c.surface.get_pollution(c.position))
 end
 
 function Toxic:GetPlayerArmor(player)
-    local inv = player.get_inventory(defines.inventory.character_armor)
+    -- Read the character's armor inventory directly: player.get_inventory returns nil
+    -- in remote view, which made the mod treat an armored character as unarmored.
+    local c = player.character
+    if not c then return 0, nil end
+    local inv = c.get_inventory(defines.inventory.character_armor)
     if not inv then return 0, nil end
     local count = inv.get_item_count()
     if count > 0 then


### PR DESCRIPTION
В remote view (`controller=remote`, фича 2.0) `player.get_inventory(character_armor)` возвращает `nil`, а `player.position` = позиция камеры. Из-за этого мод считал бронированного персонажа голым и брал загрязнение в точке обзора → урон по HP вплоть до смерти.

Воспроизведение: открыть карту (remote view), стоя бронированным в загрязнении → мгновенный урон с жёлтым алертом, брони как будто нет.

**Фикс** — читать броню и позицию из `player.character`, а не из `player`:
- `GetPlayerArmor` → `player.character.get_inventory(character_armor)`
- `GetPollution` → `player.character.position` / `.surface`

В 1.1 код тот же, но remote view не существовало — баг 2.0-специфичный. Проверено в игре: в remote view с power-armor `net=0`, урона нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)