### PR TITLE
Добавляет производственные пакеты в стоимость Cement processing 4

### DIFF
--- a/mods/zzzparanoidal/final-fixes/technologies.lua
+++ b/mods/zzzparanoidal/final-fixes/technologies.lua
@@ -302,6 +302,7 @@ if data.raw.technology["angels-stone-smelting-4"] then
 		{ "automation-science-pack", 1 },
 		{ "logistic-science-pack", 1 },
 		{ "chemical-science-pack", 1 },
+		{ "production-science-pack", 1 },
 	}) --меняем цену на цемент 4
 	data.raw.technology["angels-stone-smelting-4"].unit.count = 200 --меняем цену на цемент 4
 end


### PR DESCRIPTION
## Что

`angels-stone-smelting-4` (Cement processing 4) теперь требует `production-science-pack`: 🔴🟢🔵🟣 вместо 🔴🟢🔵. Цена (`count = 200`) не меняется.

## Почему

Tier 4 цемента стоил науку **ниже тиром**, чем tier 3 (cement 3 = 🔴🟢🔵🟣, cement 4 = 🔴🟢🔵). Фиолетовая банка добавлена, чтобы стоимость соответствовала тиру технологии.

Фиолетовая наука достижима по цепочке зависимостей: cement 4 → cement 3, а cement 3 уже требует `production-science-pack` — предупреждения о незадекларированной зависимости пакета не возникает.

<img width="612" height="369" alt="image" src="https://github.com/user-attachments/assets/aa3ec1cf-31cc-4f7a-bc9a-acd2a4795183" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)