### PR TITLE
Чинит мёртвые гарды цены дробилки/флотации/рафинировки Mk-tier

### DIFF
--- a/mods/zzzparanoidal/final-fixes/recipies.lua
+++ b/mods/zzzparanoidal/final-fixes/recipies.lua
@@ -270,9 +270,9 @@ paralib.bobmods.lib.recipe.remove_ingredient("angels-ore-crusher-2", "angels-ore
 paralib.bobmods.lib.recipe.add_new_ingredient("angels-ore-crusher-2", { type = "item", name = "angels-ore-crusher", amount = 2 })
 paralib.bobmods.lib.recipe.remove_ingredient("angels-ore-crusher-3", "angels-ore-crusher-2")
 paralib.bobmods.lib.recipe.add_new_ingredient("angels-ore-crusher-3", { type = "item", name = "angels-ore-crusher-2", amount = 2 })
-if data.raw.item["ore-crusher-4"] then
-	paralib.bobmods.lib.recipe.remove_ingredient("ore-crusher-4", "angels-ore-crusher-3")
-	paralib.bobmods.lib.recipe.add_new_ingredient("ore-crusher-4", { type = "item", name = "angels-ore-crusher-3", amount = 2 })
+if data.raw.item["angels-ore-crusher-4"] then
+	paralib.bobmods.lib.recipe.remove_ingredient("angels-ore-crusher-4", "angels-ore-crusher-3")
+	paralib.bobmods.lib.recipe.add_new_ingredient("angels-ore-crusher-4", { type = "item", name = "angels-ore-crusher-3", amount = 2 })
 end
 
 paralib.bobmods.lib.recipe.remove_ingredient("angels-ore-sorting-facility-2", "angels-ore-sorting-facility")
@@ -301,10 +301,10 @@ paralib.bobmods.lib.recipe.add_new_ingredient(
 	"angels-ore-floatation-cell-3",
 	{ type = "item", name = "angels-ore-floatation-cell-2", amount = 2 }
 )
-if data.raw.item["ore-floatation-cell-4"] then
-	paralib.bobmods.lib.recipe.remove_ingredient("ore-floatation-cell-4", "angels-ore-floatation-cell-3")
+if data.raw.item["angels-ore-floatation-cell-4"] then
+	paralib.bobmods.lib.recipe.remove_ingredient("angels-ore-floatation-cell-4", "angels-ore-floatation-cell-3")
 	paralib.bobmods.lib.recipe.add_new_ingredient(
-		"ore-floatation-cell-4",
+		"angels-ore-floatation-cell-4",
 		{ type = "item", name = "angels-ore-floatation-cell-3", amount = 2 }
 	)
 end
@@ -322,9 +322,9 @@ paralib.bobmods.lib.recipe.add_new_ingredient(
 
 paralib.bobmods.lib.recipe.remove_ingredient("angels-ore-refinery-2", "angels-ore-refinery")
 paralib.bobmods.lib.recipe.add_new_ingredient("angels-ore-refinery-2", { type = "item", name = "angels-ore-refinery", amount = 2 })
-if data.raw.item["ore-refinery-3"] then
-	paralib.bobmods.lib.recipe.remove_ingredient("ore-refinery-3", "angels-ore-refinery-2")
-	paralib.bobmods.lib.recipe.add_new_ingredient("ore-refinery-3", { type = "item", name = "angels-ore-refinery-2", amount = 2 })
+if data.raw.item["angels-ore-refinery-3"] then
+	paralib.bobmods.lib.recipe.remove_ingredient("angels-ore-refinery-3", "angels-ore-refinery-2")
+	paralib.bobmods.lib.recipe.add_new_ingredient("angels-ore-refinery-3", { type = "item", name = "angels-ore-refinery-2", amount = 2 })
 end
 
 paralib.bobmods.lib.recipe.remove_ingredient("angels-filtration-unit-2", "angels-filtration-unit")


### PR DESCRIPTION
## Что

В `zzzparanoidal/final-fixes/recipies.lua` три блока, поднимающие цену Mk-tier зданий (требовать 2× предыдущего тира), ссылались на **не-префиксные** имена прототипов, которых в 2.0 нет — миграция переименовала их в `angels-*`. Гард `if data.raw.item["ore-…"]` всегда ложен → блок не выполнялся → апгрейд цены 1→2 терялся.

Исправлены имена в гарде и в вызовах `remove_ingredient`/`add_new_ingredient`:

| Рецепт | Было (2.0) | Стало = как в 1.1 |
|---|---|---|
| `angels-ore-crusher-4` | 1× crusher-3 | **2× crusher-3** |
| `angels-ore-floatation-cell-4` | 1× cell-3 | **2× cell-3** |
| `angels-ore-refinery-3` | 1× refinery-2 | **2× refinery-2** |

## Проверка

Сверено с дампами `--dump-data` для 2.0 и 1.1: в 1.1 все три требуют 2× предыдущего тира, в 2.0 (до фикса) — 1×. Остальные аналогичные гарды в файле (`angels-filtration-unit-3`, `angels-crystallizer-3`, `angels-washing-plant-3/4`) используют правильные префиксные имена и работают.

🤖 Generated with [Claude Code](https://claude.com/claude-code)