### PR TITLE
Убирает пустой "+" эффект у factory-recursion-t1/t2

### DIFF
--- a/mods/zzzparanoidal/data-final-fixes.lua
+++ b/mods/zzzparanoidal/data-final-fixes.lua
@@ -51,6 +51,7 @@ require("tweaks.technology.pumps")
 require("tweaks.technology.yuoki")
 require("tweaks.technology.concrete")
 require("tweaks.technology.fuel")
+require("tweaks.technology.factorissimo-recursion-clean") -- убираем пустой "+" эффект у factory-recursion-t1/t2
 
 require("tweaks.custom.main-menu-background")
 require("tweaks.custom.map-gen-presets")

--- a/mods/zzzparanoidal/tweaks/technology/factorissimo-recursion-clean.lua
+++ b/mods/zzzparanoidal/tweaks/technology/factorissimo-recursion-clean.lua
@@ -1,0 +1,20 @@
+-- Factorissimo вешает на factory-recursion-t1/t2 пустой эффект-заглушку
+-- {type="nothing", effect_description=""}, который рисуется как голый "+".
+-- Способность вкладывать фабрики выдаётся скриптом (factory-buildings.lua, по .researched),
+-- эффект косметический. Убираем только пустые nothing-эффекты; эффект эволюции
+-- (research_evolution_factor, у него описание — таблица) не трогаем.
+if not mods["factorissimo-2-notnotmelon"] then
+    return
+end
+
+for _, name in pairs({ "factory-recursion-t1", "factory-recursion-t2" }) do
+    local tech = data.raw.technology[name]
+    if tech and tech.effects then
+        for i = #tech.effects, 1, -1 do
+            local effect = tech.effects[i]
+            if effect.type == "nothing" and effect.effect_description == "" then
+                table.remove(tech.effects, i)
+            end
+        end
+    end
+end


### PR DESCRIPTION
## Что

С техов `factory-recursion-t1` и `factory-recursion-t2` (Factorissimo) убран пустой эффект-заглушка `{type="nothing", effect_description=""}`, который в разделe Effects рисуется как голый красный `+` без текста.

## Почему безопасно

- Способность вкладывать фабрики выдаётся **скриптом** (`factory-buildings.lua` проверяет `.researched`), а не этим эффектом — механика не зависит от него.
- Удаляются **только** `nothing`-эффекты с пустым `effect_description == ""`. Эффект эволюции от `research_evolution_factor` (описание — таблица) не затрагивается, график остаётся.
- Дерево, пререквизиты и разблокировки рецептов не меняются.

Точечно по двум техам, под гардом `mods["factorissimo-2-notnotmelon"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)