### PR TITLE
Убирает пустой "+" эффект у factory-recursion-t1/t2

### DIFF
--- a/mods/zzzparanoidal/data-final-fixes.lua
+++ b/mods/zzzparanoidal/data-final-fixes.lua
@@ -51,6 +51,7 @@ require("tweaks.technology.pumps")
 require("tweaks.technology.yuoki")
 require("tweaks.technology.concrete")
 require("tweaks.technology.fuel")
+require("tweaks.technology.factorissimo-recursion-clean") -- убираем пустой "+" эффект у factory-recursion-t1/t2
 
 require("tweaks.custom.main-menu-background")
 require("tweaks.custom.map-gen-presets")

--- a/mods/zzzparanoidal/tweaks/technology/factorissimo-recursion-clean.lua
+++ b/mods/zzzparanoidal/tweaks/technology/factorissimo-recursion-clean.lua
@@ -1,0 +1,20 @@
+-- Factorissimo вешает на factory-recursion-t1/t2 пустой эффект-заглушку
+-- {type="nothing", effect_description=""}, который рисуется как голый "+".
+-- Способность вкладывать фабрики выдаётся скриптом (factory-buildings.lua, по .researched),
+-- эффект косметический. Убираем только пустые nothing-эффекты; эффект эволюции
+-- (research_evolution_factor, у него описание — таблица) не трогаем.
+if not mods["factorissimo-2-notnotmelon"] then
+    return
+end
+
+for _, name in pairs({ "factory-recursion-t1", "factory-recursion-t2" }) do
+    local tech = data.raw.technology[name]
+    if tech and tech.effects then
+        for i = #tech.effects, 1, -1 do
+            local effect = tech.effects[i]
+            if effect.type == "nothing" and effect.effect_description == "" then
+                table.remove(tech.effects, i)
+            end
+        end
+    end
+end

--- a/mods/zzzparanoidal/tweaks/technology/factorissimo-recursion-clean.lua
+++ b/mods/zzzparanoidal/tweaks/technology/factorissimo-recursion-clean.lua
@@ -1,8 +1,5 @@
--- Factorissimo вешает на factory-recursion-t1/t2 пустой эффект-заглушку
--- {type="nothing", effect_description=""}, который рисуется как голый "+".
--- Способность вкладывать фабрики выдаётся скриптом (factory-buildings.lua, по .researched),
--- эффект косметический. Убираем только пустые nothing-эффекты; эффект эволюции
--- (research_evolution_factor, у него описание — таблица) не трогаем.
+-- Рекурсия выдаётся скриптом (по .researched), а не эффектом, поэтому пустой
+-- nothing-эффект Factorissimo (голый "+") можно безопасно убрать.
 if not mods["factorissimo-2-notnotmelon"] then
     return
 end


### PR DESCRIPTION
## Что

С техов `factory-recursion-t1` и `factory-recursion-t2` (Factorissimo) убран пустой эффект-заглушка `{type="nothing", effect_description=""}`, который в разделе Effects рисуется как голый красный `+` без текста.

## Почему безопасно

- Способность вкладывать фабрики выдаётся **скриптом** (`factory-buildings.lua` проверяет `.researched`), а не этим эффектом — механика не зависит от него.
- Удаляются **только** `nothing`-эффекты с пустым `effect_description == ""`. Эффект эволюции от `research_evolution_factor` (описание — таблица) не затрагивается, график остаётся.
- Дерево, пререквизиты и разблокировки рецептов не меняются.

Точечно по двум техам, под гардом `mods["factorissimo-2-notnotmelon"]`. Проверено в игре.
<img width="469" height="260" alt="Снимок экрана 2026-06-08 в 10 04 00" src="https://github.com/user-attachments/assets/52246729-b354-4afe-954b-8c8c1a9a4dd2" />
<img width="471" height="269" alt="Снимок экрана 2026-06-08 в 12 15 47" src="https://github.com/user-attachments/assets/c906fcec-4c0f-43dd-8e60-980a978c3078" />

