### PR TITLE
Обновляет Robot256Lib 2.0.14 → 2.0.15 (фикс краша replaceCarriage)

### DIFF
--- a/mods/Robot256Lib/changelog.txt
+++ b/mods/Robot256Lib/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.0.15
+Date: 2026-06-06
+  Bugfixes:
+    - Fix crash when modifying train groups during carriage replacement (thanks to Lampotrias).
+---------------------------------------------------------------------------------------------------
 Version: 2.0.14
 Date: 2026-01-17
   Bugfixes:

--- a/mods/Robot256Lib/info.json
+++ b/mods/Robot256Lib/info.json
@@ -1,6 +1,6 @@
 {
   "name": "Robot256Lib",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "title": "Robot256's Library",
   "author": "robot256",
   "contact": "",

--- a/mods/Robot256Lib/script/carriage_replacement.lua
+++ b/mods/Robot256Lib/script/carriage_replacement.lua
@@ -289,6 +289,10 @@ local function replaceCarriage(carriage, newName, raiseBuilt, raiseDestroy, flip
     if train_group then
       -- Group will set the basic schedule and interrupts
       newTrain.group = train_group
+      -- Re-fetch: assigning the train to a group replaces its LuaSchedule
+      -- object, invalidating the handle obtained above (used by add_record
+      -- below and by .current after the if/else).
+      newSchedule = newTrain.get_schedule()
       -- We still need to restore the schedule to include any temporary stops specific to this train.
       -- Add entries individually to avoid affecting other trains in the group.
       for k=1,#train_schedule_records do
@@ -305,6 +309,10 @@ local function replaceCarriage(carriage, newName, raiseBuilt, raiseDestroy, flip
     end
     
     newTrain.manual_mode = manual_mode
+    -- Re-fetch here too: set_records/set_interrupts (no-group path) or the group
+    -- assignment can invalidate the handle obtained earlier, and reading .current
+    -- on a stale LuaSchedule crashes.
+    newSchedule = newTrain.get_schedule()
     -- Send train to correct station in schedule
     if newSchedule.current ~= destination and destination <= newSchedule.get_record_count() then
       newTrain.go_to_station(destination)


### PR DESCRIPTION
## Что

Обновление `Robot256Lib` 2.0.14 → 2.0.15. Изменены 3 файла: `info.json`, `changelog.txt`, `script/carriage_replacement.lua`. Новых/удалённых файлов нет.

## Почему

Фикс краша при замене вагона (`replaceCarriage`) у поездов в группах: handle `LuaSchedule`, полученный заранее, инвалидировался после назначения поезда в группу / `set_records`, и последующее чтение `.current` со «протухшего» handle крашило игру. В 2.0.15 schedule перечитывается через `get_schedule()` после таких операций.

Changelog 2.0.15:
> Fix crash when modifying train groups during carriage replacement (thanks to Lampotrias).

Баг был зарепорчен нами апстриму ([robot256/Robot256Lib#11](https://github.com/robot256/Robot256Lib/issues/11), CLOSED) и исправлен автором. Тянем готовый релиз.

🤖 Generated with [Claude Code](https://claude.com/claude-code)