### PR TITLE
Возвращает высыпание содержимого при разрушении (item-drop)

### DIFF
--- a/mods/zzzparanoidal/control.lua
+++ b/mods/zzzparanoidal/control.lua
@@ -1,4 +1,5 @@
 require("controls.heroturrets_script") -- скрипт разжалования турелей
+require("controls.spilled_items") -- высыпание содержимого сущности при разрушении (настройка item-drop)
 -- ###############################################################################################
 -- from some corpse marker
 script.on_event(defines.events.on_pre_player_died, function(event)

--- a/mods/zzzparanoidal/controls/spilled_items.lua
+++ b/mods/zzzparanoidal/controls/spilled_items.lua
@@ -1,0 +1,72 @@
+-- Высыпание содержимого сущности на землю при её разрушении (порт фичи 1.1 «SpilledItems»).
+-- Гейт — startup-настройка "item-drop" (settings.lua). В 1.1 жила в control.lua, при порте на 2.0 выпала,
+-- хотя настройка и локаль остались — игрок видел включённую опцию, которая ничего не делала.
+-- 2.0-API: spill_item_stack принимает табличную форму {position=, stack=, enable_looted=}.
+-- Стек с гридом (броня с модулями) отдаём как LuaItemStack, иначе теряется установленная экипировка.
+
+-- Набор инвентарей повторяет 1.1: сундук, багажник, боезапас турели + output/модули/топливо/прогар.
+local inventory_ids = {
+	defines.inventory.chest,
+	defines.inventory.car_trunk,
+	defines.inventory.turret_ammo,
+}
+
+local function spill_inventory(surface, position, inventory)
+	if not inventory then
+		return
+	end
+	for i = 1, #inventory do
+		local stack = inventory[i]
+		if stack and stack.valid_for_read then
+			if stack.grid then
+				-- броня/сетка: передаём сам LuaItemStack, иначе потеряются установленные модули
+				surface.spill_item_stack({ position = position, stack = stack, enable_looted = false })
+			else
+				surface.spill_item_stack({
+					position = position,
+					stack = { name = stack.name, count = stack.count },
+					enable_looted = false,
+				})
+			end
+		end
+	end
+	inventory.clear()
+end
+
+local function spill_on_death(event)
+	local entity = event.entity
+	if not (entity and entity.valid) then
+		return
+	end
+	local surface = entity.surface
+	local position = entity.position
+
+	-- экипировка, установленная в саму сущность (её grid)
+	local grid = entity.grid
+	if grid then
+		for _, equipment in pairs(grid.equipment) do
+			local take_result = equipment.prototype.take_result
+			if take_result then
+				surface.spill_item_stack({
+					position = position,
+					stack = { name = take_result.name, count = 1 },
+					enable_looted = false,
+				})
+			end
+		end
+		grid.clear()
+	end
+
+	for _, id in pairs(inventory_ids) do
+		spill_inventory(surface, position, entity.get_inventory(id))
+	end
+	spill_inventory(surface, position, entity.get_output_inventory())
+	spill_inventory(surface, position, entity.get_module_inventory())
+	spill_inventory(surface, position, entity.get_fuel_inventory())
+	spill_inventory(surface, position, entity.get_burnt_result_inventory())
+end
+
+-- startup-настройка читается один раз при загрузке control-стадии: нет галки — нет обработчика
+if settings.startup["item-drop"].value then
+	script.on_event(defines.events.on_entity_died, spill_on_death)
+end

--- a/mods/zzzparanoidal/controls/spilled_items.lua
+++ b/mods/zzzparanoidal/controls/spilled_items.lua
@@ -1,10 +1,6 @@
--- Высыпание содержимого сущности на землю при её разрушении (порт фичи 1.1 «SpilledItems»).
--- Гейт — startup-настройка "item-drop" (settings.lua). В 1.1 жила в control.lua, при порте на 2.0 выпала,
--- хотя настройка и локаль остались — игрок видел включённую опцию, которая ничего не делала.
--- 2.0-API: spill_item_stack принимает табличную форму {position=, stack=, enable_looted=}.
--- Стек с гридом (броня с модулями) отдаём как LuaItemStack, иначе теряется установленная экипировка.
+-- Порт фичи 1.1 «SpilledItems»: при разрушении сущности высыпает её содержимое на землю.
+-- Гейт — startup-настройка "item-drop".
 
--- Набор инвентарей повторяет 1.1: сундук, багажник, боезапас турели + output/модули/топливо/прогар.
 local inventory_ids = {
 	defines.inventory.chest,
 	defines.inventory.car_trunk,
@@ -18,16 +14,8 @@ local function spill_inventory(surface, position, inventory)
 	for i = 1, #inventory do
 		local stack = inventory[i]
 		if stack and stack.valid_for_read then
-			if stack.grid then
-				-- броня/сетка: передаём сам LuaItemStack, иначе потеряются установленные модули
-				surface.spill_item_stack({ position = position, stack = stack, enable_looted = false })
-			else
-				surface.spill_item_stack({
-					position = position,
-					stack = { name = stack.name, count = stack.count },
-					enable_looted = false,
-				})
-			end
+			-- сам LuaItemStack сохраняет качество/прочность/grid/теги
+			surface.spill_item_stack({ position = position, stack = stack, enable_looted = false })
 		end
 	end
 	inventory.clear()
@@ -41,7 +29,6 @@ local function spill_on_death(event)
 	local surface = entity.surface
 	local position = entity.position
 
-	-- экипировка, установленная в саму сущность (её grid)
 	local grid = entity.grid
 	if grid then
 		for _, equipment in pairs(grid.equipment) do
@@ -49,7 +36,7 @@ local function spill_on_death(event)
 			if take_result then
 				surface.spill_item_stack({
 					position = position,
-					stack = { name = take_result.name, count = 1 },
+					stack = { name = take_result.name, count = 1, quality = equipment.quality.name },
 					enable_looted = false,
 				})
 			end
@@ -66,7 +53,6 @@ local function spill_on_death(event)
 	spill_inventory(surface, position, entity.get_burnt_result_inventory())
 end
 
--- startup-настройка читается один раз при загрузке control-стадии: нет галки — нет обработчика
 if settings.startup["item-drop"].value then
 	script.on_event(defines.events.on_entity_died, spill_on_death)
 end


### PR DESCRIPTION
## Что видит игрок

Стартовая настройка zzzparanoidal «Разрушенные сундуки высыпают содержимое» / «Destroyed chest spills contents» (`item-drop`) включена по умолчанию, но не работает: разрушенные сундуки, машины, турели и т.п. не рассыпают содержимое на землю.

## Корень проблемы

В 1.1 фича жила в `control.lua` — обработчик `SpilledItems` на `on_entity_died`. При порте на 2.0 сам обработчик выпал, а настройка (`settings.lua`) и её локаль (RU/EN) остались. Получилась мёртвая опция, включённая по умолчанию: галка есть, кода за ней нет (`grep on_entity_died|spill|item-drop` по zzz → только объявление настройки и локаль).

## Решение

Новый модуль `controls/spilled_items.lua` — порт фичи под 2.0:

- `surface.spill_item_stack{position=, stack=, enable_looted=false}` (табличная форма 2.0);
- стек с гридом (броня с модулями) отдаётся как `LuaItemStack`, чтобы не потерять установленную экипировку;
- self-gating: обработчик вешается только при `settings.startup["item-drop"].value` — нет галки, нет обработчика;
- набор инвентарей как в 1.1: `chest` / `car_trunk` / `turret_ammo` + `output` / `module` / `fuel` / `burnt` + grid самой сущности.

Подключён через `require("controls.spilled_items")` в `control.lua`. Коллизий по `on_entity_died` в сборке нет (heroturrets-скрипт вешает только select-area).

## Проверка

- `luac -p` обоих файлов — OK.
- В игре: полный сундук → `/c game.player.selected.die()` → содержимое рассыпается рядом. Настройка выключена и перезапуск → не рассыпается.
