### PR TITLE
Чинит анлок condensator при выключенном burner-phase

### DIFF
--- a/mods/zzzparanoidal/final-fixes/technologies.lua
+++ b/mods/zzzparanoidal/final-fixes/technologies.lua
@@ -107,10 +107,6 @@ paralib.bobmods.lib.tech.add_recipe_unlock("angels-basic-chemistry-2", "angels-c
 --целюлозное волокно в переработку древесины
 paralib.bobmods.lib.tech.add_recipe_unlock("angels-bio-wood-processing", "angels-cellulose-fiber-raw-wood")
 -------------------------------------------------------------------------------------------------
---ремкомплект в электричество
-paralib.bobmods.lib.recipe.enabled("repair-pack", false)
-paralib.bobmods.lib.tech.add_recipe_unlock("bob-electricity", "repair-pack")
--------------------------------------------------------------------------------------------------
 --конденсатор в электричество
 -- bob-electricity есть только при burner-phase (bobmods-burnerphase); с aai-industry он выключен
 -- → техи нет, анлок молча отваливается. Фолбэк на ванильную electricity (тот же ранний тир).

--- a/mods/zzzparanoidal/final-fixes/technologies.lua
+++ b/mods/zzzparanoidal/final-fixes/technologies.lua
@@ -107,13 +107,16 @@ paralib.bobmods.lib.tech.add_recipe_unlock("angels-basic-chemistry-2", "angels-c
 --целюлозное волокно в переработку древесины
 paralib.bobmods.lib.tech.add_recipe_unlock("angels-bio-wood-processing", "angels-cellulose-fiber-raw-wood")
 -------------------------------------------------------------------------------------------------
+-- bob-electricity есть только при burner-phase (bobmods-burnerphase). С aai-industry burner-phase
+-- выключен → техи нет, анлок молча отваливается. Берём ванильную electricity как ранний эквивалент.
+local elec = data.raw.technology["bob-electricity"] and "bob-electricity" or "electricity"
 --ремкомплект в электричество
 paralib.bobmods.lib.recipe.enabled("repair-pack", false)
-paralib.bobmods.lib.tech.add_recipe_unlock("bob-electricity", "repair-pack")
+paralib.bobmods.lib.tech.add_recipe_unlock(elec, "repair-pack")
 -------------------------------------------------------------------------------------------------
 --конденсатор в электричество
 paralib.bobmods.lib.recipe.enabled("condensator", false)
-paralib.bobmods.lib.tech.add_recipe_unlock("bob-electricity", "condensator")
+paralib.bobmods.lib.tech.add_recipe_unlock(elec, "condensator")
 -------------------------------------------------------------------------------------------------
 --паровой манипулятор в автоматику
 paralib.bobmods.lib.recipe.enabled("bob-steam-inserter", false)

--- a/mods/zzzparanoidal/final-fixes/technologies.lua
+++ b/mods/zzzparanoidal/final-fixes/technologies.lua
@@ -107,14 +107,14 @@ paralib.bobmods.lib.tech.add_recipe_unlock("angels-basic-chemistry-2", "angels-c
 --целюлозное волокно в переработку древесины
 paralib.bobmods.lib.tech.add_recipe_unlock("angels-bio-wood-processing", "angels-cellulose-fiber-raw-wood")
 -------------------------------------------------------------------------------------------------
--- bob-electricity есть только при burner-phase (bobmods-burnerphase). С aai-industry burner-phase
--- выключен → техи нет, анлок молча отваливается. Берём ванильную electricity как ранний эквивалент.
-local elec = data.raw.technology["bob-electricity"] and "bob-electricity" or "electricity"
 --ремкомплект в электричество
 paralib.bobmods.lib.recipe.enabled("repair-pack", false)
-paralib.bobmods.lib.tech.add_recipe_unlock(elec, "repair-pack")
+paralib.bobmods.lib.tech.add_recipe_unlock("bob-electricity", "repair-pack")
 -------------------------------------------------------------------------------------------------
 --конденсатор в электричество
+-- bob-electricity есть только при burner-phase (bobmods-burnerphase); с aai-industry он выключен
+-- → техи нет, анлок молча отваливается. Фолбэк на ванильную electricity (тот же ранний тир).
+local elec = data.raw.technology["bob-electricity"] and "bob-electricity" or "electricity"
 paralib.bobmods.lib.recipe.enabled("condensator", false)
 paralib.bobmods.lib.tech.add_recipe_unlock(elec, "condensator")
 -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Симптом
После обновления Bob's 2.1 рецепт `condensator` (Capacitor) — «Рецепт не изучен», в Факторипедии нет анлока. Ломает электронную цепочку пака (`condensator` — базовый узел из KaoExtended). Воспроизводится и в новой игре.

## Причина
`condensator` анлочится только через `bob-electricity`. Эта теха создаётся в bobtech лишь при `bobmods-burnerphase=true`. Обновление вернуло апстрим-хардкод bobtech, форсящий burner-phase в `false` при `aai-industry` → `bob-electricity` не создаётся → `add_recipe_unlock` молча отваливается → `condensator` остаётся `enabled=false` без анлока.

## Фикс
`final-fixes/technologies.lua`:
- `condensator`: фолбэк анлока на `electricity`, когда `bob-electricity` отсутствует (тот же ранний тир — copper-cable/small-electric-pole).
- `repair-pack`: убрана мёртвая дублирующая привязка к `bob-electricity` — у него своя теха `repair-pack`, `enabled=false` сохраняется.

## Проверка
Сравнение дампов `--dump-data` до/после: `condensator` снова анлочится (`electricity`); `repair-pack` остаётся `enabled=false` на своей техе, с нуля не крафтится. По диффу дампов — `condensator` единственная новая «потеря» этого обновления (остальные сироты давние).
