### PR TITLE
Совместимость длины подземных лент с модом Show Max Underground Distance

### DIFF
--- a/mods/zzzparanoidal/data-updates.lua
+++ b/mods/zzzparanoidal/data-updates.lua
@@ -2,3 +2,6 @@
 require("tweaks.recipe.angels-components") -- Сюда складывать все рецепты из группы (item-group) = angels-components
 require("tweaks.recipe.angels-power") -- Сюда складывать все рецепты из группы (item-group) = angels-power
 require("tweaks.recipe.production") -- Сюда складывать все рецепты из группы (item-group) = production
+
+-- Длины подземных лент: на data-updates, чтобы show-max-underground-distance (data-final-fixes) читал финал
+require("tweaks.entity.underground-belt-distance")

--- a/mods/zzzparanoidal/tweaks/entity/belts.lua
+++ b/mods/zzzparanoidal/tweaks/entity/belts.lua
@@ -33,13 +33,9 @@ if mods.boblogistics then
 	data.raw["underground-belt"]["turbo-underground-belt"].speed = 6 * base_speed
 	data.raw["splitter"]["turbo-splitter"].speed = 6 * base_speed
 
-	data.raw["underground-belt"]["turbo-underground-belt"].max_distance = 23
-
 	-- 16x Green Belt
 	data.raw["transport-belt"]["bob-ultimate-transport-belt"].speed = 12 * base_speed
 	data.raw["underground-belt"]["bob-ultimate-underground-belt"].speed = 12 * base_speed
 	data.raw["splitter"]["bob-ultimate-splitter"].speed = 12 * base_speed
-
-	data.raw["underground-belt"]["bob-ultimate-underground-belt"].max_distance = 27
 end
 

--- a/mods/zzzparanoidal/tweaks/entity/underground-belt-distance.lua
+++ b/mods/zzzparanoidal/tweaks/entity/underground-belt-distance.lua
@@ -1,0 +1,15 @@
+-- Длины тоннелей подземных лент (дамп 1.1 Oberhaul: basic/fast/express; turbo/ultimate — тиры Bob's).
+-- На data-updates, чтобы show-max-underground-distance (печёт индикатор дальности в data-final-fixes)
+-- читал уже финальные значения.
+local function set_ug_distance(name, dist)
+	local ug = data.raw["underground-belt"][name]
+	if ug then
+		ug.max_distance = dist
+	end
+end
+
+set_ug_distance("bob-basic-underground-belt", 5)
+set_ug_distance("fast-underground-belt", 11)
+set_ug_distance("express-underground-belt", 17)
+set_ug_distance("turbo-underground-belt", 23)
+set_ug_distance("bob-ultimate-underground-belt", 27)

--- a/mods/zzzparanoidal/tweaks/recipe/oberhaul-belt-port.lua
+++ b/mods/zzzparanoidal/tweaks/recipe/oberhaul-belt-port.lua
@@ -1,4 +1,4 @@
--- Порт belt-рецептов и дистанций тоннелей из мода Oberhaul (1.1: beltrecipes.lua + beltentities.lua). Значения — дамп 1.1.
+-- Порт belt-рецептов из мода Oberhaul (1.1: beltrecipes.lua). Значения — дамп 1.1.
 
 local function set_ingredients(recipe_name, ingredients)
   local recipe = data.raw.recipe[recipe_name]
@@ -46,11 +46,3 @@ set_ingredients("turbo-splitter", {
   { type = "item", name = "bob-cobalt-steel-bearing", amount = 4 },
   { type = "item", name = "bob-cobalt-steel-gear-wheel", amount = 10 },
 })
-
-local function set_ug_distance(name, dist)
-  local ug = data.raw["underground-belt"][name]
-  if ug then ug.max_distance = dist end
-end
-set_ug_distance("bob-basic-underground-belt", 5)
-set_ug_distance("fast-underground-belt", 11)
-set_ug_distance("express-underground-belt", 17)


### PR DESCRIPTION
## Проблема
Мод Show Max Underground Distance рисует индикатор максимальной дальности
подземных лент и труб. Он вычисляет индикатор на стадии data-final-fixes,
читая max_distance прототипа.

В zzzparanoidal длины подземных лент (bob-basic / fast / express / turbo /
ultimate) задавались тоже в data-final-fixes, но позже мода: Show Max
Underground Distance грузится раньше по алфавиту и от zzz не зависит. В итоге
мод печёт индикатор из длины ДО наших изменений, и подсказка не совпадает с
фактической дальностью тоннеля.

## Решение
Установка длин подземных лент вынесена из data-final-fixes в data-updates —
на стадию раньше. Стадии Factorio выполняются строго по порядку для всех модов
(data → data-updates → data-final-fixes), поэтому к моменту, когда Show Max
Underground Distance читает max_distance, значения уже финальные, и мод сам
рисует корректный индикатор. Независимо от порядка загрузки модов.

## Что не меняется
Сами длины тоннелей не тронуты — изменилась только стадия, на которой они
задаются. Баланс идентичен.

Трубы не затронуты: их дальность задаёт boblogistics ещё в data.lua, поэтому
мод и так видит финальные значения.
