### PR TITLE
Big-Monsters: возврат частоты событий к уровню 1.1

### DIFF
--- a/mods/zzzparanoidal/settings-final-fixes.lua
+++ b/mods/zzzparanoidal/settings-final-fixes.lua
@@ -46,6 +46,11 @@ if mods["__RITEG__"] then
 end
 --биг монстры
 if mods["Big-Monsters"] then
+    -- 1.1: event-days=100, tree-events-chance=0, max=365. В 2.0 автор сменил дефолты (6 / 1.0) и срезал потолок до 20.
+    -- maximum_value правим первым: иначе значение/дефолт 100 нелегальны при max=20.
+    data.raw["int-setting"]["bm-event-days"].maximum_value = 365
+    set_settings_default_value("int-setting", "bm-event-days", 100)
+    set_settings_default_value("double-setting", "bm-tree-events-chance", 0)
     set_settings_default_value("double-setting", "bm-biterzilla-min_evo", 0.4)
     set_settings_default_value("int-setting", "bm-difficulty-level", 5)
     set_settings_default_value("int-setting", "bm-invasion-chance", 0)


### PR DESCRIPTION
## Проблема

В 2.0 события Big-Monsters стали приходить кратно чаще, чем в сборке для 1.1. Автор мода сменил значения по умолчанию (`bm-event-days` 100→6, `bm-tree-events-chance` 0→1.0) и срезал потолок `bm-event-days` с 365 до 20. Прежняя подстройка пака жила правкой внутри `settings.lua` самого мода и потерялась при его обновлении.

## Изменения

`zzzparanoidal/settings-final-fixes.lua` (внутри блока `if mods["Big-Monsters"]`):

- `bm-event-days.maximum_value = 365` — снимаем урезанный потолок 20; правится первой строкой, иначе значение/дефолт 100 невалидны при `max=20`;
- `default bm-event-days = 100` — события ≈ раз в 11–12 ч вместо ~42 мин;
- `default bm-tree-events-chance = 0` — события от вырубки деревьев выключены.

## Поведение

- **Новые игры / чистая установка** — значения применяются автоматически.
- **Существующий `mod-settings.dat`** — `set_settings_default_value` не перебивает уже сохранённое значение (ограничение Factorio). Правится разово в меню: *Настройки модов → Карта* → «Event interval (game days)» = 100, «Tree mining event chance %» = 0 (настройки без перевода, отображаются на английском).

1.1 версия:
<img width="574" height="18" alt="Снимок экрана 2026-06-29 в 09 22 34" src="https://github.com/user-attachments/assets/b1be7554-f41a-4136-9c12-a81118979f3b" />

2.0 до фикса:
<img width="631" height="30" alt="Снимок экрана 2026-06-29 в 09 16 36" src="https://github.com/user-attachments/assets/f3a5af36-723e-4ce8-89bd-693839db036a" />

2.0 после фикса:
<img width="678" height="30" alt="Снимок экрана 2026-06-29 в 09 42 01" src="https://github.com/user-attachments/assets/4c05e9eb-2522-475c-a2dd-8238f61f7222" />

