### PR TITLE
zzz: en-локаль для новых предметов (flame_car, pistol-rearm-ammo, настройки wire)

### DIFF
--- a/mods/zzzparanoidal/locale/en/locale.cfg
+++ b/mods/zzzparanoidal/locale/en/locale.cfg
@@ -32,6 +32,7 @@ hiend_loco=Maglev locomotive
 hiend_wagon=Maglev cargo wagon
 hiend_fluid_wagon=Maglev fluid wagon
 super_charger=Battery charger MK4
+flame_car=Flamethrower Car
 
 
 [item-description]
@@ -73,6 +74,7 @@ reg-casting=__1__ __2__
 die-casting=Die Casting of __1__ __2__
 sand-casting=Sand Casting of __1__ __2__
 ASE-metal-die-wash=Die Cast Scrubbing
+pistol-rearm-ammo=Ammo from pistol
 
 
 [entity-name]
@@ -94,6 +96,7 @@ bi-bio-greenhouse-2=Greenhouse MK2
 bi-bio-greenhouse-3=Greenhouse MK3
 bi-bio-reactor-2=Bioreactor MK2
 bi-bio-reactor-3=Bioreactor MK3
+flame_car=Flamethrower Car
 
 [entity-description]
 artillery-turret-prototype=Artillery prototype for destroying enemy bases.
@@ -122,6 +125,7 @@ angels-alloys-smelting=Advanced Alloys Smelting
 angels-ironworks=Advanced Ironworks
 hiend_train=Maglev trains
 super_charger=Battery charger MK4
+flame_car=Flamethrower Car
 
 [technology-description]
 alien-artifact=Technology that allows alien artifacts to be fused and transmuted into other species.
@@ -149,6 +153,8 @@ baa-arrow-tint=Arrow tint
 item-drop=Destroyed chest spills contents
 newbie_resourse=All resources richness x5
 zzz-settings=How to enable PARANOIDAL fine settings
+wire=Enable: thicker circuit wires
+copper_wire=Enable: thicker copper wires
 
 [mod-setting-description]
 paranoidal-flowfix-min-time=Recipes with a shorter time will be proportionaly increased in time, ingredients and products amount.
@@ -162,6 +168,8 @@ res_loc_e=Enables the replacement of standard graphics with graphics from the Yu
 item-drop=Destroyed chest spills contents
 newbie_resourse=NOT RECOMMENDED to disable if you are newbie to Paranoidal
 zzz-settings=If you're reading this, you're probably looking for a bunch of hidden and subtle settings. You won't find them here until you turn off the "Advanced PARANOIDAL Settings" mod...
+wire=Enables replacement of the default circuit-wire graphics with sprites from the ThickerLines mod (graphics only).
+copper_wire=Enables replacement of the default copper-wire graphics with sprites from the ThickerLines mod (graphics only).
 
 
 [item-group-name]


### PR DESCRIPTION
## Что и зачем

У части собственных сущностей `zzzparanoidal` не было английской локали — только русские ключи (наследие ru-first разработки; проверил по ветке `factorio1.1` — там та же картина, en для них не было и тогда). На английском интерфейсе это давало `Unknown key` (см. `flame_car`, `pistol-rearm-ammo`).

## Изменения

Добавлены недостающие en-ключи в `zzzparanoidal/locale/en/locale.cfg`:

- `flame_car` — `item-name` / `entity-name` / `technology-name`
- `pistol-rearm-ammo` — `recipe-name`
- `wire` / `copper_wire` — `mod-setting-name` + описания

## Эффект

- `Unknown key` уходит на английском, и на русском тоже (Factorio фолбэкает на `en`, пока нет `ru`).
- Строки становятся видимы Crowdin как source — **русский добьётся через Crowdin в будущем**: для `flame_car` существующий `ru` из `zzz` импортируется как дефолт, для `pistol-rearm-ammo` перевод делается в вебе.

## Что намеренно не трогал

Мёртвый легаси 1.1 (`description.radar-*`, `spacex-bio-*`, `string.water-pumpjack`) — в 2.0 эти ключи из кода не вызываются, `Unknown key` не дают.
