### PR TITLE
Возврат железной трубы из плит (регрессия #267)

### DIFF
--- a/mods/zzzparanoidal/data-final-fixes.lua
+++ b/mods/zzzparanoidal/data-final-fixes.lua
@@ -39,7 +39,6 @@ require("tweaks.recipe.module")
 require("tweaks.recipe.poles") -- Изменение рецептов ЛЭП
 require("tweaks.recipe.yuoki")
 require("tweaks.recipe.concrete")
-require("tweaks.recipe.pipes")
 require("tweaks.recipe.groups")
 require("tweaks.recipe.fuel")
 require("tweaks.recipe.science-packs")

--- a/mods/zzzparanoidal/tweaks/recipe/pipes.lua
+++ b/mods/zzzparanoidal/tweaks/recipe/pipes.lua
@@ -1,4 +1,0 @@
-require("paralib")
-paralib.bobmods.lib.recipe.hide("pipe")
-paralib.bobmods.lib.recipe.hide("pipe-to-ground")
-


### PR DESCRIPTION
## Возврат железной трубы из плит

Железная труба (`pipe`) и труба-под-землю (`pipe-to-ground`) пропали из ручного крафта — их скрывал `zzzparanoidal/tweaks/recipe/pipes.lua`.

### Причина
Регрессия из #267 (обновление Bob's 2.1 / Angels). Раньше файл прятал **каменные** трубы:
```lua
paralib.bobmods.lib.recipe.hide("bob-stone-pipe")
paralib.bobmods.lib.recipe.hide("bob-stone-pipe-to-ground")
```
В #267 их заменили на базовую **железную**:
```lua
paralib.bobmods.lib.recipe.hide("pipe")
paralib.bobmods.lib.recipe.hide("pipe-to-ground")
```
Похоже на ошибочный find/replace: каменные трубы Bob's в 2.0 удалил (тот hide и так был мёртвым no-op), а вместо чистки его перенаправили на `pipe` — и железная труба из плит исчезла из меню. При этом медная/стальная/бронзовая из плит остались видны, так что железная выпала как несостыковка.

В 1.1 железная труба из плит была доступна (не скрыта).

### Фикс
Удалил `tweaks/recipe/pipes.lua` и его `require` (прятать больше нечего — каменных труб в Bob's 2.0 нет). Литьё железной трубы (`angels-iron-pipe-casting`) остаётся как было.

### Проверка
`--dump-data` чистый; `pipe`/`pipe-to-ground` больше не hidden, крафтятся из iron-plate на `basic-fluid-handling` — рядом с медной/стальной.
