### PR TITLE
Актуализация SpaceMod после добавления bobequipment: 1.1-цена, без дублей наук

### DIFF
--- a/mods/zzzparanoidal/tweaks/technology/spacemod-port.lua
+++ b/mods/zzzparanoidal/tweaks/technology/spacemod-port.lua
@@ -1,34 +1,22 @@
 require("__zzzparanoidal__.paralib")
 
--- SpaceModFeorasFork под 1.1: ×10 стоимости космо-техов + space/advanced-logistic/military-наука.
+-- Восстанавливаем 1.1-цену космо-техов, которую 2.0-форк потерял: в 1.1 SpaceMod/technology-bobs.lua
+-- bob_coefficient был = 10 и умножал стоимость всех космо-техов, а форк обнулил его до 1.
+-- Возвращаем тот же ×10 поверх модовых count. Ранние техи выходят точно как в 1.1 (60k–240k);
+-- FTL-ветка остаётся прогрессивной лесенкой из 2.0-форка (в 1.1 была плоско 2M) — оставлено намеренно.
+-- Наборы наук и bob-пререквизиты навешивает сам мод (гейт bobequipment проходит), дублировать не нужно.
 if mods["SpaceModFeorasFork"] then
 	local techs = {
 		"space-assembly", "space-construction", "space-casings", "protection-fields",
 		"fusion-reactor", "space-thrusters", "fuel-cells", "habitation", "life-support-systems",
 		"spaceship-command", "laser-cannon", "astrometrics", "ftl-theory-A", "ftl-theory-B",
-		"ftl-theory-C", "ftl-theory-D1", "ftl-theory-D2", "ftl-propulsion",
+		"ftl-theory-C", "ftl-theory-D", "ftl-theory-D1", "ftl-theory-D2", "ftl-propulsion",
 		"exploration-satellite", "space-ai-robots", "space-fluid-tanks", "space-cartography",
 	}
-	local military = {
-		["spaceship-command"] = true, ["ftl-theory-D1"] = true,
-		["ftl-theory-D2"] = true, ["ftl-propulsion"] = true,
-	}
-	local function add_pack(unit, pack)
-		if not data.raw.tool[pack] then return end
-		for _, ing in ipairs(unit.ingredients) do
-			if (ing.name or ing[1]) == pack then return end
-		end
-		table.insert(unit.ingredients, { pack, 1 })
-	end
 	for _, name in ipairs(techs) do
 		local t = data.raw.technology[name]
-		if t and t.unit and t.unit.ingredients then
+		if t and t.unit and t.unit.count then
 			t.unit.count = math.floor(t.unit.count * 10)
-			add_pack(t.unit, "bob-advanced-logistic-science-pack")
-			add_pack(t.unit, "space-science-pack")
-			if military[name] then
-				add_pack(t.unit, "military-science-pack")
-			end
 		end
 	end
 end


### PR DESCRIPTION
После добавления `bobequipment` в модпак гейт Bob-интеграции в `SpaceModFeorasFork/data-final-fixes.lua` наконец проходит, и мод сам навешивает на космо-техи `bob-advanced-logistic-science-pack` и bob-пререквизиты. Раньше блок молча пропускался (условие требовало `bobequipment`, которого не было), поэтому эти паки мы добавляли вручную в `spacemod-port.lua`. Теперь это дубль — убираем.

Второе: 2.0-форк обнулил `bob_coefficient` (в 1.1 `SpaceMod/technology-bobs.lua` он был `= 10` и умножал стоимость всех космо-техов), из-за чего исследования стали примерно в 10 раз дешевле оригинала. Возвращаем `× 10` поверх модовых count:

- ранние техи (`space-assembly` … `laser-cannon`) снова точно как в 1.1 (60k–240k);
- FTL-ветку оставляем прогрессивной лесенкой из 2.0-форка (500k–2M) — в 1.1 она была плоско 2M, но лесенка удобнее, оставлено намеренно.

**Проверка:** `--dump-data` на 2.0.77 — все 23 теха дают ожидаемые count; наборы наук (`space`/`military`/`bob-advanced-logistic`) и bob-пререквизиты на месте, их обеспечивает сам мод.