### PR TITLE
Пластиковая подземная труба: +1 тайл, чтобы покрыть два железных участка встык

### DIFF
--- a/mods/zzzparanoidal/data-updates.lua
+++ b/mods/zzzparanoidal/data-updates.lua
@@ -3,5 +3,6 @@ require("tweaks.recipe.angels-components") -- Сюда складывать вс
 require("tweaks.recipe.angels-power") -- Сюда складывать все рецепты из группы (item-group) = angels-power
 require("tweaks.recipe.production") -- Сюда складывать все рецепты из группы (item-group) = production
 
--- Длины подземных лент: на data-updates, чтобы show-max-underground-distance (data-final-fixes) читал финал
+-- Длины подземных лент и труб: на data-updates, чтобы show-max-underground-distance (data-final-fixes) читал финал
 require("tweaks.entity.underground-belt-distance")
+require("tweaks.entity.underground-pipe-distance")

--- a/mods/zzzparanoidal/tweaks/entity/underground-pipe-distance.lua
+++ b/mods/zzzparanoidal/tweaks/entity/underground-pipe-distance.lua
@@ -1,0 +1,20 @@
+-- Длины тоннелей подземных труб.
+-- Пластик = ровно два участка железной/медной трубы встык (замена 2-в-1): два участка по D
+-- перекрывают 2*D + 1 тайлов (D на каждый + 1 тайл стыка между ними), при базовых D=10 → 21.
+-- На data-updates, чтобы show-max-underground-distance (печёт индикатор дальности в data-final-fixes)
+-- читал уже финальное значение, иначе подсветка следующего участка не совпадёт с реальной дальностью.
+local function pipe_ug_connection(name)
+	local pipe = data.raw["pipe-to-ground"][name]
+	if not pipe or not pipe.fluid_box then return nil end
+	for _, connection in pairs(pipe.fluid_box.pipe_connections) do
+		if connection.max_underground_distance then
+			return connection
+		end
+	end
+end
+
+local iron = pipe_ug_connection("pipe-to-ground") -- железная = медная по дальности
+local plastic = pipe_ug_connection("bob-plastic-pipe-to-ground")
+if iron and plastic then
+	plastic.max_underground_distance = iron.max_underground_distance * 2 + 1
+end


### PR DESCRIPTION
По сути — +1 тайл к дальности пластиковой подземной трубы (20 → 21).

Пластик по умолчанию тянул на 20 — это ровно 2× железной/медной трубы (2×10), но на 1 тайл не хватало, чтобы заменить два железных/медных участка встык: между ними есть тайл стыка. Добавляем именно его: 2·D + 1 = 21 при базовых D=10.

- Дальность `bob-plastic-pipe-to-ground` считается из фактической дальности `pipe-to-ground` как `2·D + 1`, а не хардкодится — переживает смену базовой дальности и включение bob's ugdistanceoverhaul.
- Новый файл `tweaks/entity/underground-pipe-distance.lua` (по образцу `underground-belt-distance.lua`), подключён в `data-updates.lua` на стадии data-updates: так `show-max-underground-distance` (печёт индикатор в data-final-fixes) читает финальное значение, и подсветка следующего участка совпадает с реальным вылетом.
