### PR TITLE
Сортировка складов Angel's и Optera по сетке в Logistics

### DIFF
--- a/mods/zzzparanoidal/data-final-fixes.lua
+++ b/mods/zzzparanoidal/data-final-fixes.lua
@@ -40,6 +40,8 @@ require("tweaks.recipe.poles") -- Изменение рецептов ЛЭП
 require("tweaks.recipe.yuoki")
 require("tweaks.recipe.concrete")
 require("tweaks.recipe.groups")
+require("tweaks.recipe.angels-warehouse-tiers") -- все тиры Angel's-складов (mk1..mk4) одним блоком в Logistics
+require("tweaks.recipe.optera-warehouse-sort") -- Optera warehouse (6×6) и storehouse (3×3) — каждый одним рядом
 require("tweaks.recipe.fuel")
 require("tweaks.recipe.science-packs")
 require("tweaks.recipe.warfare") -- рецепт artillery-turret: добавление artillery-turret-prototype (файл не был подключён при порте)

--- a/mods/zzzparanoidal/tweaks/recipe/angels-warehouse-tiers.lua
+++ b/mods/zzzparanoidal/tweaks/recipe/angels-warehouse-tiers.lua
@@ -1,0 +1,44 @@
+-- Extended Angels (extendedangels/prototypes/overrides/warehouses.lua) при наличии
+-- Angel's Industries уводит склады mk2/mk3/mk4 в отдельную вкладку angels-logistics.
+-- Возвращаем их подгруппы в группу logistics, подряд за базовым mk1
+-- (angels-warehouse). Каждый тир — своя подгруппа = свой ряд: mk1, mk2, mk3, mk4.
+if not (mods["angelsaddons-storage"] and data.raw["item-subgroup"]["angels-warehouse"]) then
+	return
+end
+
+local tier_subgroups = {
+	["angels-warehouses-2"] = "ae[chests-warehouse]-b",
+	["angels-warehouses-3"] = "ae[chests-warehouse]-c",
+	["angels-warehouses-4"] = "ae[chests-warehouse]-d",
+}
+for name, order in pairs(tier_subgroups) do
+	local sg = data.raw["item-subgroup"][name]
+	if sg then
+		sg.group = "logistics"
+		sg.order = order
+	end
+end
+
+local cols = {
+	["angels-warehouse"] = "a",
+	["angels-warehouse-active-provider"] = "b",
+	["angels-warehouse-passive-provider"] = "c",
+	["angels-warehouse-storage"] = "d",
+	["angels-warehouse-buffer"] = "e",
+	["angels-warehouse-requester"] = "f",
+}
+local function set_order(proto, order)
+	if proto then
+		proto.order = order
+	end
+end
+
+for base, col in pairs(cols) do
+	for tier = 1, 4 do
+		local name = (tier == 1) and base or (base .. "-mk" .. tier)
+		set_order(data.raw.recipe[name], col)
+		set_order(data.raw.item[name], col)
+		set_order(data.raw.container[name], col)
+		set_order(data.raw["logistic-container"][name], col)
+	end
+end

--- a/mods/zzzparanoidal/tweaks/recipe/optera-warehouse-sort.lua
+++ b/mods/zzzparanoidal/tweaks/recipe/optera-warehouse-sort.lua
@@ -1,0 +1,45 @@
+-- Warehousing (Optera): basic-склады сидят в vanilla-подгруппе "storage", а
+-- логистические — в "logistic-network", поэтому разбросаны по разным рядам.
+-- Собираем каждое семейство в свою подгруппу-ряд по сетке постройки:
+-- 6×6 (warehouse) и 3×3 (storehouse), порядок колонок как у Angel's-складов
+-- (basic, active, passive, storage, buffer, requester).
+if not mods["Warehousing"] then
+	return
+end
+
+data:extend({
+	{ type = "item-subgroup", name = "optera-storehouse", group = "logistics", order = "ae[chests-warehouse]-e" },
+	{ type = "item-subgroup", name = "optera-warehouse", group = "logistics", order = "ae[chests-warehouse]-f" },
+})
+
+local cols = {
+	["basic"] = "a",
+	["active-provider"] = "b",
+	["passive-provider"] = "c",
+	["storage"] = "d",
+	["buffer"] = "e",
+	["requester"] = "f",
+}
+
+local function set_sub(proto, sg, order)
+	if proto then
+		proto.subgroup = sg
+		proto.order = order
+	end
+end
+
+for _, fam in ipairs({
+	{ prefix = "warehouse", sg = "optera-warehouse" },
+	{ prefix = "storehouse", sg = "optera-storehouse" },
+}) do
+	for suffix, col in pairs(cols) do
+		local name = fam.prefix .. "-" .. suffix
+		set_sub(data.raw.recipe[name], fam.sg, col)
+		set_sub(data.raw.item[name], fam.sg, col)
+		set_sub(data.raw.container[name], fam.sg, col)
+		set_sub(data.raw["logistic-container"][name], fam.sg, col)
+	end
+	local linked = "linked-" .. fam.prefix
+	set_sub(data.raw.item[linked], fam.sg, "g")
+	set_sub(data.raw["linked-container"][linked], fam.sg, "g")
+end


### PR DESCRIPTION
## Что и зачем

Во вкладке Logistics склады были разбросаны:

- Тиры Angel's-складов (mk2/mk3/mk4) Extended Angels при наличии Angel's Industries уводит в отдельную вкладку `angels-logistics` тремя разными подгруппами — в отрыве от базового mk1.
- Склады Optera (Warehousing): `basic` сидели в vanilla-подгруппе `storage`, а логистические — в `logistic-network`, из-за чего basic и его логистические варианты оказывались в разных рядах.

## Изменения

Всё сведено в аккуратные ряды во вкладке Logistics, единым порядком колонок (basic, active, passive, storage, buffer, requester):

- **Angel's** — тиры mk1..mk4 возвращены в группу `logistics`, каждый тир своей подгруппой-рядом, подряд за базовым.
- **Optera** — две подгруппы по сетке постройки: 6×6 (warehouse) и 3×3 (storehouse), каждая одним рядом.

Оба мода остаются в сборке как есть. Меняется только раскладка в меню крафта/инвентаре — `subgroup`/`order` на recipe + item + entity. Рецепты, вместимости и сами постройки не затрагиваются.

<img width="748" height="1008" alt="image" src="https://github.com/user-attachments/assets/05b520ee-65d2-4dac-b484-3561c061b869" />


## Файлы

- `mods/zzzparanoidal/tweaks/recipe/angels-warehouse-tiers.lua` (новый)
- `mods/zzzparanoidal/tweaks/recipe/optera-warehouse-sort.lua` (новый)
- `mods/zzzparanoidal/data-final-fixes.lua` — подключение