### PR TITLE
Чинит недоступность улучшенного сплавления инвара

### DIFF
--- a/mods/zzzparanoidal/final-fixes/technologies.lua
+++ b/mods/zzzparanoidal/final-fixes/technologies.lua
@@ -140,7 +140,7 @@ paralib.bobmods.lib.tech.add_prerequisite("concrete", "angels-stone-smelting-2")
 paralib.bobmods.lib.tech.add_prerequisite("bi-tech-wooden-storage-1", "bi-tech-resin-extraction") --деревянный ящик
 paralib.bobmods.lib.tech.add_prerequisite("angels-steel-smelting-1", "angels-nitrogen-processing-1") --сталь
 paralib.bobmods.lib.tech.add_prerequisite("angels-steel-smelting-1", "angels-flare-stack") --сталь
-paralib.bobmods.lib.tech.add_prerequisite("angels-invar-smelting-1", "bob-zinc-processing") --сталь
+paralib.bobmods.lib.tech.add_prerequisite("angels-invar-smelting-1", "bob-brass-processing") --латунь перед инваром, как в прогрессии 1.1
 paralib.bobmods.lib.tech.add_prerequisite("plastics", "angels-plastic-1") --пластик
 
 --Фикс магния


### PR DESCRIPTION
## Что изменено

- Заменён скрытый и отключённый prerequisite `bob-zinc-processing` у `angels-invar-smelting-1` на активный `bob-brass-processing`.
- Сохранена прогрессия 1.1: старый `zinc-processing` шёл после выплавки латуни и открывал латунные детали.

## Причина

После обновления Bob’s/Angel’s `bob-zinc-processing` скрывается (`hidden = true`, `enabled = false`), но `zzzparanoidal` добавлял его как prerequisite уже после Angel’s override. Из-за этого исследование инвара нельзя было начать.

## Проверка

- Factorio 2.0.77 `--dump-data` — exit 0.
- Итоговые prerequisite: сталь, никель, `bob-brass-processing`.
- Скрытого `bob-zinc-processing` в цепочке нет.
- Транзитивная цепочка из 47 технологий не содержит hidden/disabled/missing prerequisite.
- `luac -p` и `git diff --check` проходят.
- Проверено в игре на существующем сохранении.
