### PR TITLE
Fix: тиры био-ферм/теплиц/реакторов MK2/MK3 не открывались ни одной технологией

### DIFF
--- a/mods-metadata/!expected.json
+++ b/mods-metadata/!expected.json
@@ -1078,7 +1078,7 @@
     {
       "name": "zzzparanoidal",
       "version": "8.1.7",
-      "contentHash": "ad3a72b5b5e114b60d943b9b679573a7",
+      "contentHash": "1bec6d5bb0c7518adc3b8593e61259a2",
       "metadataHash": "409c51bffa2477d958e3c1c9b2e40f2fda623117556f51424cfa53d5f546bbef"
     }
   ]

--- a/mods-metadata/!expected.json
+++ b/mods-metadata/!expected.json
@@ -1078,7 +1078,7 @@
     {
       "name": "zzzparanoidal",
       "version": "8.1.7",
-      "contentHash": "1bec6d5bb0c7518adc3b8593e61259a2",
+      "contentHash": "4a6b6d0c19e041cffb976455d84cf92d",
       "metadataHash": "409c51bffa2477d958e3c1c9b2e40f2fda623117556f51424cfa53d5f546bbef"
     }
   ]

--- a/mods/zzzparanoidal/final-fixes/technologies.lua
+++ b/mods/zzzparanoidal/final-fixes/technologies.lua
@@ -50,7 +50,6 @@ paralib.bobmods.lib.tech.add_prerequisite("fluid-handling", "logistic-science-pa
 paralib.bobmods.lib.tech.add_prerequisite("remelting-alloy-mixer-1", "logistic-science-pack")
 paralib.bobmods.lib.tech.add_prerequisite("bob-chemical-processing-2", "logistic-science-pack")
 paralib.bobmods.lib.tech.add_prerequisite("angels-ironworks-1", "logistic-science-pack")
-paralib.bobmods.lib.tech.add_prerequisite("bi-tech-bio-farming-2", "logistic-science-pack")
 paralib.bobmods.lib.tech.add_prerequisite("adv-seed-extraction", "logistic-science-pack")
 paralib.bobmods.lib.tech.add_prerequisite("nanobots-cliff", "logistic-science-pack")
 --синие банки

--- a/mods/zzzparanoidal/tweaks/entity/bio-mod.lua
+++ b/mods/zzzparanoidal/tweaks/entity/bio-mod.lua
@@ -1,8 +1,10 @@
 require("__zzzparanoidal__.paralib")
-paralib.bobmods.lib.tech.add_recipe_unlock("bi-tech-bio-farming-3", "bi-bio-farm-2") --открываем рецепт биофермы 2
-paralib.bobmods.lib.tech.add_recipe_unlock("bi-tech-bio-farming-3", "bi-bio-greenhouse-2") --открываем рецепт теплицы 2
-paralib.bobmods.lib.tech.add_recipe_unlock("bi-tech-bio-farming-4", "bi-bio-farm-3") --открываем рецепт биофермы 3
-paralib.bobmods.lib.tech.add_recipe_unlock("bi-tech-bio-farming-4", "bi-bio-greenhouse-3") --открываем рецепт теплицы 3
+-- BI 2.0 не создаёт техи bi-tech-bio-farming-2/3/4 (были в BI 1.1 new_tech.lua, удалены при конверсии).
+-- Тиры вешаем на техи-хосты рецептов роста, которые они крафтят: MK2 -> fertilizer (bi-*-3), MK3 -> advanced-biotechnology (bi-*-4).
+paralib.bobmods.lib.tech.add_recipe_unlock("bi-tech-fertilizer", "bi-bio-farm-2") --открываем рецепт биофермы 2
+paralib.bobmods.lib.tech.add_recipe_unlock("bi-tech-fertilizer", "bi-bio-greenhouse-2") --открываем рецепт теплицы 2
+paralib.bobmods.lib.tech.add_recipe_unlock("bi-tech-advanced-biotechnology", "bi-bio-farm-3") --открываем рецепт биофермы 3
+paralib.bobmods.lib.tech.add_recipe_unlock("bi-tech-advanced-biotechnology", "bi-bio-greenhouse-3") --открываем рецепт теплицы 3
 
 data.raw["recipe"]["bi-logs-3"].category = "biofarm-mod-farm-2" -- Прячем рецепты под новую ферму 2
 data.raw["recipe"]["bi-logs-4"].category = "biofarm-mod-farm-3" -- Прячем рецепты под новую ферму 3
@@ -17,11 +19,11 @@ paralib.bobmods.lib.recipe.set_ingredients(
 	"bi-bio-reactor",
 	{ { type = "item", name = "assembling-machine-1", amount = 2}, { type = "item", name = "steel-plate", amount = 20}, { type = "item", name = "bob-basic-circuit-board", amount = 5} }
 ) --баланс рецепта биореактора 1
-paralib.bobmods.lib.tech.add_recipe_unlock("bi-tech-biomass-reprocessing-1", "bi-bio-reactor-2") --открываем рецепт биореактора 2
-paralib.bobmods.lib.tech.add_recipe_unlock("bi-tech-biomass-reprocessing-2", "bi-bio-reactor-3") --открываем рецепт биореактора 3
+-- BI 2.0 не создаёт техи bi-tech-biomass-reprocessing-1/2 (были в BI 1.1); рецепты biomass-2/3 открывает advanced-biotechnology — туда же вешаем реакторы
+paralib.bobmods.lib.tech.add_recipe_unlock("bi-tech-advanced-biotechnology", "bi-bio-reactor-2") --открываем рецепт биореактора 2
+paralib.bobmods.lib.tech.add_recipe_unlock("bi-tech-advanced-biotechnology", "bi-bio-reactor-3") --открываем рецепт биореактора 3
 data.raw["recipe"]["bi-biomass-2"].category = "biofarm-mod-bioreactor-2" -- Прячем рецепты под новый биореактор 2
 data.raw["recipe"]["bi-biomass-3"].category = "biofarm-mod-bioreactor-3" -- Прячем рецепты под новый биореактор 2
-paralib.bobmods.lib.tech.add_prerequisite("bi-tech-bio-farming-3", "concrete") -- Технологии под Бетон
 
 paralib.bobmods.lib.recipe.remove_ingredient("bi-bio-greenhouse", "glass")
 data.raw.item["bi-bio-greenhouse"].subgroup = "bio-bio-farm-fluid-entity"

--- a/mods/zzzparanoidal/tweaks/entity/bio-mod.lua
+++ b/mods/zzzparanoidal/tweaks/entity/bio-mod.lua
@@ -23,7 +23,7 @@ paralib.bobmods.lib.recipe.set_ingredients(
 paralib.bobmods.lib.tech.add_recipe_unlock("bi-tech-advanced-biotechnology", "bi-bio-reactor-2") --открываем рецепт биореактора 2
 paralib.bobmods.lib.tech.add_recipe_unlock("bi-tech-advanced-biotechnology", "bi-bio-reactor-3") --открываем рецепт биореактора 3
 data.raw["recipe"]["bi-biomass-2"].category = "biofarm-mod-bioreactor-2" -- Прячем рецепты под новый биореактор 2
-data.raw["recipe"]["bi-biomass-3"].category = "biofarm-mod-bioreactor-3" -- Прячем рецепты под новый биореактор 2
+data.raw["recipe"]["bi-biomass-3"].category = "biofarm-mod-bioreactor-3" -- Прячем рецепты под новый биореактор 3
 
 paralib.bobmods.lib.recipe.remove_ingredient("bi-bio-greenhouse", "glass")
 data.raw.item["bi-bio-greenhouse"].subgroup = "bio-bio-farm-fluid-entity"


### PR DESCRIPTION
## Проблема
Постройки-тиры из нашего слоя — `bi-bio-farm-2/3`, `bi-bio-greenhouse-2/3`, `bi-bio-reactor-2/3` — недоступны в игре: их рецепты (`enabled=false`) не открывает ни одна технология, построить MK2/MK3 нельзя.

## Причина
Привязка вешалась на техи `bi-tech-bio-farming-2/3/4` и `bi-tech-biomass-reprocessing-1/2`. Они были в Bio Industries 1.1 (`prototypes/new_tech.lua`), но в 2.0-конверсии мода (`Bio_Industries_2`) удалены. `bobmods.lib.tech.add_recipe_unlock` при отсутствии целевого теха молча выходит (guard по `data.raw.technology[...]`) — привязка не создаётся и следа в дампе не оставляет. Сами тиры — наш контент (в моде их нет), порт перенёс имена техов из 1.1 дословно.

## Что сделано
Тиры перепривязаны к существующим техам 2.0 по механике — тир вешается на тот же тех, что открывает рецепты роста, которые тир крафтит:
- `bi-bio-farm-2`, `bi-bio-greenhouse-2` → `bi-tech-fertilizer` (открывает `bi-*-3`)
- `bi-bio-farm-3`, `bi-bio-greenhouse-3` → `bi-tech-advanced-biotechnology` (открывает `bi-*-4`)
- `bi-bio-reactor-2/3` → `bi-tech-advanced-biotechnology` (открывает `bi-biomass-2/3`)

Убраны два мёртвых `add_prerequisite` на несуществующие `bi-tech-bio-farming-2/3`. Рецепты роста (`bi-logs/seed/seedling-*`) не трогали — их привязывает сам Bio Industries.

Файлы:
- `mods/zzzparanoidal/tweaks/entity/bio-mod.lua`
- `mods/zzzparanoidal/final-fixes/technologies.lua`

## Проверка
`--dump-data` до/после: все 6 построек получили тех-привязку (0 сирот), дамп грузится без ошибок.

## Заметка
Реакторы MK1/2/3 открываются одним техом (`advanced-biotechnology`): в 1.1 рецепты `biomass-1/2/3` стояли на трёх ступенчатых техах (`biomass`, `biomass-reprocessing-1/2`), а BI 2.0 свёл все три на один `advanced-biotechnology`. Поэтому привязка «по рецепту, который крафтит тир» даёт всем реакторам общий тех. Отдельная ступенчатость реакторов — при желании, отдельным изменением.
