### PR TITLE
Фикс направлений труб fluid_box у био-реактора MK2/3

### DIFF
--- a/mods/zzzparanoidal/prototypes/entity/bio-content.lua
+++ b/mods/zzzparanoidal/prototypes/entity/bio-content.lua
@@ -695,7 +695,7 @@ data:extend({ -- ###############################################################
 				base_level = -1,
 				pipe_connections = {
 					{
-						direction = 8,
+						direction = 0,
 						flow_direction = "input",
 						position = { 0, -1 },
 					},
@@ -712,7 +712,7 @@ data:extend({ -- ###############################################################
 				pipe_connections = {
 					{
 						flow_direction = "input",
-						direction = 8,
+						direction = 4,
 						position = { 1, 0 },
 					},
 				},
@@ -743,7 +743,7 @@ data:extend({ -- ###############################################################
 				base_level = 1,
 				pipe_connections = {
 					{
-						direction = 8,
+						direction = 12,
 						flow_direction = "output",
 						position = { -1, -1 },
 					},
@@ -759,7 +759,7 @@ data:extend({ -- ###############################################################
 				base_level = 1,
 				pipe_connections = {
 					{
-						direction = 8,
+						direction = 12,
 						flow_direction = "output",
 						position = { -1, 1 },
 					},
@@ -862,7 +862,7 @@ data:extend({ -- ###############################################################
 				base_level = -1,
 				pipe_connections = {
 					{
-						direction = 8,
+						direction = 0,
 						flow_direction = "input",
 						position = { 0, -1 },
 					},
@@ -879,7 +879,7 @@ data:extend({ -- ###############################################################
 				pipe_connections = {
 					{
 						flow_direction = "input",
-						direction = 8,
+						direction = 4,
 						position = { 1, 0 },
 					},
 				},
@@ -910,7 +910,7 @@ data:extend({ -- ###############################################################
 				base_level = 1,
 				pipe_connections = {
 					{
-						direction = 8,
+						direction = 12,
 						flow_direction = "output",
 						position = { -1, -1 },
 					},
@@ -926,7 +926,7 @@ data:extend({ -- ###############################################################
 				base_level = 1,
 				pipe_connections = {
 					{
-						direction = 8,
+						direction = 12,
 						flow_direction = "output",
 						position = { -1, 1 },
 					},


### PR DESCRIPTION
## Что и зачем
У био-реактора MK2/3 (контент zzzparanoidal) все 5 подключений `fluid_box` имели `direction = 8` (юг) при разных позициях. Из-за этого 4 из 5 труб смотрели не в свою сторону — патрубки и стрелки жидкостей сбивались в кучу, подключаться к реактору неудобно.

## Что сделано
Направления приведены к эталону MK1 из Bio_Industries_2:

| Позиция | Было | Стало |
|---|---|---|
| `[0,-1]` (сверху) | S | **N** |
| `[1,0]` (справа) | S | **E** |
| `[0,1]` (снизу) | S | S |
| `[-1,-1]` / `[-1,1]` (слева) | S | **W** |

Farm/greenhouse не трогал — их `fluid_boxes` нормализует Assembler Pipe Passthrough (в дампе направления уже верные); реактор этот мод не переопределяет, поэтому наши некорректные `direction` доходили до игры.

## Проверка
`--dump-data`: направления труб реактора MK2/3 теперь совпадают с MK1 (`N / E / S / W`).

Пре-существующий баг порта 1.1→2.0, не связан с графической PR #333.

Было:
<img width="195" height="267" alt="Screenshot 2026-08-25 at 09 38 10" src="https://github.com/user-attachments/assets/9780b5e2-c5a3-46c1-9f5a-df15f6085fac" />

стало ок