### PR TITLE
Возвращает крафт вольфрамовой трубы и marathon-цены труб после Bob's 2.1

### DIFF
--- a/mods/zzzparanoidal/final-fixes/technologies.lua
+++ b/mods/zzzparanoidal/final-fixes/technologies.lua
@@ -159,9 +159,6 @@ paralib.bobmods.lib.tech.add_prerequisite("bob-radar-2", "radar") --Добави
 
 paralib.bobmods.lib.tech.remove_recipe_unlock("bob-tungsten-alloy-processing", "bob-tungsten-carbide-2x")
 paralib.bobmods.lib.recipe.hide("bob-tungsten-carbide-2x")
--- copper-tungsten-труба РАСПРЯТАНА: после удаления нитинол-трубы (Bob's 2.1) она верхний тир и делается обычным рецептом (молтена copper-tungsten нет).
-paralib.bobmods.lib.recipe.hide("bob-tungsten-pipe")
-paralib.bobmods.lib.recipe.hide("bob-tungsten-pipe-to-ground")
 
 --фикс недоступности исследования артиллерии
 paralib.bobmods.lib.tech.remove_prerequisite("artillery", "radar")

--- a/mods/zzzparanoidal/tweaks/recipe/marathon-port.lua
+++ b/mods/zzzparanoidal/tweaks/recipe/marathon-port.lua
@@ -72,10 +72,10 @@ paralib.bobmods.lib.recipe.set_ingredients("bob-brass-pipe-to-ground", {
 	{ type = "item", name = "bob-brass-alloy", amount = 15 },
 })
 
-paralib.bobmods.lib.recipe.set_ingredient("bob-titanium-pipe", { type = "item", name = "bob-silicon-nitride", amount = 4 })
+paralib.bobmods.lib.recipe.set_ingredient("bob-ceramic-pipe", { type = "item", name = "bob-silicon-nitride", amount = 4 })
 
-paralib.bobmods.lib.recipe.set_ingredients("bob-titanium-pipe-to-ground", {
-	{ type = "item", name = "bob-titanium-pipe", amount = 25 },
+paralib.bobmods.lib.recipe.set_ingredients("bob-ceramic-pipe-to-ground", {
+	{ type = "item", name = "bob-ceramic-pipe", amount = 25 },
 	{ type = "item", name = "bob-silicon-nitride", amount = 15 },
 })
 
@@ -91,13 +91,6 @@ paralib.bobmods.lib.recipe.set_ingredient("bob-tungsten-pipe", { type = "item", 
 paralib.bobmods.lib.recipe.set_ingredients("bob-tungsten-pipe-to-ground", {
 	{ type = "item", name = "bob-tungsten-pipe", amount = 25 },
 	{ type = "item", name = "tungsten-plate", amount = 10 },
-})
-
-paralib.bobmods.lib.recipe.set_ingredient("bob-copper-tungsten-pipe", { type = "item", name = "bob-nitinol-alloy", amount = 2 })
-
-paralib.bobmods.lib.recipe.set_ingredients("bob-copper-tungsten-pipe-to-ground", {
-	{ type = "item", name = "bob-copper-tungsten-pipe", amount = 250 },
-	{ type = "item", name = "bob-nitinol-alloy", amount = 100 },
 })
 
 paralib.bobmods.lib.recipe.set_ingredient("bob-copper-tungsten-pipe", { type = "item", name = "bob-copper-tungsten-alloy", amount = 2 })


### PR DESCRIPTION
## Что не работало

- Вольфрамовая труба и вольфрамовая подземная труба не крафтились вообще: рецепты были
  скрыты, других производителей у них нет. Трубу требуют 28 рецептов, включая `rocket-part`
  (30 шт), `angels-chemical-furnace-4` (30), `bob-assembling-machine-5`, `bob-storage-tank-4`,
  `bob-pumpjack-3`, `bob-artillery-wagon-3`, фермы и рафинерии мк3–4.
- Титановая труба стоила лишний нитрид кремния, медно-вольфрамовая — лишний нитинол-сплав.
- Керамическая труба шла по стоковой цене, вчетверо дешевле marathon-эталона.

## Причина

**Скрытая вольфрамовая труба.** В 1.1 (коммит 6d131b44d, «Фикс пластин вольфрама и дешевых
труб») прятались casting-рецепты ASE — литьё труб из молтена, которое обходило marathon-цены
из-за багованной таблицы `ug_multi` в ASE (tungsten 21 и copper-tungsten 5 против 150–230 у
остальных металлов, с авторской пометкой `--should be 23`). Обычный рецепт Bob's «плита →
труба» оставался единственным и рабочим.

При переносе на 2.0 скрытие переехало с casting-рецептов на сами рецепты Bob's, а литья
вольфрамовых труб в 2.0 нет вовсе — в ASE-порт эти два металла не включены именно из-за того
бага. В результате у трубы не осталось ни одного производителя, при живом анлоке от
`bob-tungsten-processing`. В #267 распрятали только медно-вольфрамовую пару, вольфрамовую
строчкой ниже пропустили.

**Двойная цена двух труб и потерянная цена керамической.** В #267 блоки marathon-баланса
переименовали по миграциям Bob's 2.1 (`bob-ceramic-pipe → bob-titanium-pipe`,
`bob-nitinol-pipe → bob-copper-tungsten-pipe`), но блоки самих титановой и медно-вольфрамовой
труб в файле уже были. `set_ingredient` добавляет один ингредиент по имени, а не заменяет
список, поэтому цены сложились. Заодно керамическая труба осталась без своего блока: Bob's
2.1 её удалил, но Angels Smelting воссоздал её у себя (`smelting-silicon.lua:301-324`,
тех `bob-ceramics`) со стоковым рецептом Bob's. Подземные версии от сложения не пострадали:
там `set_ingredients` с полной заменой, победил последний блок.

## Что меняется

| Рецепт | Было | Стало |
|---|---|---|
| `bob-tungsten-pipe` | скрыт, крафта нет | 2 вольфрамовые плиты, тех `bob-tungsten-processing` |
| `bob-tungsten-pipe-to-ground` | скрыт, крафта нет | 25 труб + 10 плит, тот же тех |
| `bob-titanium-pipe` | titanium-plate 2 + silicon-nitride 4 | titanium-plate 2 |
| `bob-copper-tungsten-pipe` | copper-tungsten-alloy 2 + nitinol-alloy 2 | copper-tungsten-alloy 2 |
| `bob-ceramic-pipe` | silicon-nitride 1 | silicon-nitride 4 |
| `bob-ceramic-pipe-to-ground` | труба 16 + нитрид 5 | труба 25 + нитрид 15 |

Все значения — эталон marathon 1.1 (`marathon/prototypes/recipe-bob-pipes.lua`).

Сравнение дампов до и после по всем 23 734 прототипам (231 тип): 0 появилось, 0 удалилось,
изменены ровно эти 6 рецептов. Миграция для сейвов не нужна — техи анлоки уже раздали,
`hidden` только скрывал рецепты из интерфейса.

## Проверка

`--dump-data` до и после каждой правки, сверка с исходниками 1.1, проверка крафта в игре.
