### PR TITLE
Сводит дубль sodium nitrate из PCPRedux в ангеловский предмет

### DIFF
--- a/mods-metadata/!expected.json
+++ b/mods-metadata/!expected.json
@@ -1077,7 +1077,7 @@
     },
     {
       "name": "zzzparanoidal",
-      "version": "8.1.8",
+      "version": "8.1.9",
       "contentHash": null,
       "metadataHash": "409c51bffa2477d958e3c1c9b2e40f2fda623117556f51424cfa53d5f546bbef"
     }

--- a/mods/zzzparanoidal/data-final-fixes.lua
+++ b/mods/zzzparanoidal/data-final-fixes.lua
@@ -169,6 +169,9 @@ for _, recipe in pairs(data.raw.recipe) do
 	end
 end
 
+-- PCPRedux: дубль sodium nitrate (старое ангеловское имя) → angels-solid-sodium-nitrate
+require("removals.pcp-sodium-nitrate-duplicate")
+
 require("tweaks.custom.restack-port") -- ReStack (Optera, 1.1) порт: размеры пачек по категориям
 --должно быть последним. После всех рецептов.
 require("tweaks.custom.flowfix")

--- a/mods/zzzparanoidal/info.json
+++ b/mods/zzzparanoidal/info.json
@@ -1,6 +1,6 @@
 {
   "name": "zzzparanoidal",
-  "version": "8.1.8",
+  "version": "8.1.9",
   "title": "!_Paranoidal",
   "factorio_version": "2.0",
   "author": "Sovigod",
@@ -36,6 +36,7 @@
     "? angelsaddons-pressuretanks",
     "? angelsindustries >= 2.0.0",
     "? extendedangels >= 0.6.9",
+    "? PCPRedux",
     "expanded-rocket-payloads-continued",
     "Bio_Industries_2",
     "? research_evolution_factor",

--- a/mods/zzzparanoidal/migrations/zzzparanoidal_8.1.9.json
+++ b/mods/zzzparanoidal/migrations/zzzparanoidal_8.1.9.json
@@ -1,0 +1,5 @@
+{
+  "item": [
+    ["solid-sodium-nitrate", "angels-solid-sodium-nitrate"]
+  ]
+}

--- a/mods/zzzparanoidal/removals/pcp-sodium-nitrate-duplicate.lua
+++ b/mods/zzzparanoidal/removals/pcp-sodium-nitrate-duplicate.lua
@@ -1,0 +1,36 @@
+-- PCPRedux (PetrochemPlus) объявляет свой item "solid-sodium-nitrate" — имя, под которым
+-- предмет жил в Angels 1.1 (в дампе 1.1 предмет один, поля от PCPRedux: он перекрывал
+-- ангеловский). angelspetrochem 2.0 переименовал его в "angels-solid-sodium-nitrate"
+-- (angelspetrochem/migrations/angelspetrochem_2.0.0.json), поэтому объявление PCPRedux
+-- перестало быть перекрытием и создаёт второй предмет с тем же названием
+-- ("Sodium Nitrate" против "Sodium nitrate").
+--
+-- 1.1-цепочка при этом разорвана: sodium-nitrate-synthesis (PCPRedux) кормит только
+-- nitrous-oxide-synthesis-2, а Angels-рецепты (nitric gasses / nitric acid) видят лишь
+-- свой предмет. Сводим обратно в один; предметы в сейвах переносит
+-- migrations/zzzparanoidal_8.1.9.json.
+--
+-- Апстрим: Pezzawinkle/PezsMods (баг живой в master). Гард снимет фикс сам, когда
+-- в PCPRedux ссылки перейдут на angels-solid-sodium-nitrate.
+
+local OLD = "solid-sodium-nitrate"
+local NEW = "angels-solid-sodium-nitrate"
+
+if not (data.raw.item[OLD] and data.raw.item[NEW]) then
+	return
+end
+
+bobmods.lib.recipe.replace_ingredient_in_all(OLD, NEW)
+
+-- аналога replace_result_in_all в boblibrary нет: результаты правим сами, обе формы записи
+for _, recipe in pairs(data.raw.recipe) do
+	for _, result in pairs(recipe.results or {}) do
+		if result.name == OLD then
+			result.name = NEW
+		elseif result[1] == OLD then
+			result[1] = NEW
+		end
+	end
+end
+
+data.raw.item[OLD] = nil


### PR DESCRIPTION
## Проблема

В паке два предмета нитрата натрия с почти одинаковым названием: `angels-solid-sodium-nitrate` («Sodium nitrate») и `solid-sodium-nitrate` («Sodium Nitrate», PCPRedux). Второй не вставляется в ангеловские рецепты и наоборот — в игре это выглядит как «предмет с тем же именем не лезет в химзавод».

## Причина

PCPRedux объявляет item под именем, которое предмет носил в Angels 1.1. `angelspetrochem` 2.0 переименовал его (`angelspetrochem/migrations/angelspetrochem_2.0.0.json`), поэтому объявление мода перестало быть перекрытием ангеловского предмета и создаёт второй. 1.1-цепочка распалась: `sodium-nitrate-synthesis` кормит только `nitrous-oxide-synthesis-2`, а `angels-solid-sodium-nitrate-processing` / `angels-sodium-nitrate-acid-processing` его не видят. В 1.1 предмет был один — в дампе 1.1 у него поля от PCPRedux, то есть мод перекрывал ангеловский.

## Что сделано

- `removals/pcp-sodium-nitrate-duplicate.lua`: ссылки во всех рецептах → `angels-solid-sodium-nitrate`, дубль-item удалён. Гард снимет фикс сам, когда ссылки переедут в апстриме.
- Миграция 8.1.9: item-rename, чтобы накопленный нитрат в активных сейвах не пропал.
- `info.json`: опц. зависимость `? PCPRedux` — порядок загрузки `data-final-fixes`.

## Верификация

Дифф дампов до/после: удалён 1 item, изменены 2 рецепта (`nitrous-oxide-synthesis-2`, `sodium-nitrate-synthesis`), больше ничего. Граф производителей/потребителей совпал с 1.1-дампом. Отдельно прогнан дамп с апстрим-патчем: результат идентичен, наш фикс при нём становится no-op.

## Апстрим

- Issue: Pezzawinkle/PezsMods#28
- PR: Pezzawinkle/PezsMods#29
