### PR TITLE
Исправляет реакцию Ruins на настройки других модов

### DIFF
--- a/mods-metadata/!expected.json
+++ b/mods-metadata/!expected.json
@@ -10,8 +10,8 @@
     {
       "name": "AbandonedRuins_updated_fork",
       "version": "1.5.7",
-      "contentHash": "4103fda28227516a43f812f51cc058b5",
-      "metadataHash": null
+      "contentHash": "ba872edefa8876f6888abdefbd8b2870",
+      "metadataHash": "6101ef0cb332d5428699df46ca5f3f92c14cf0f908e380662a0fc12bacb83b58"
     },
     {
       "name": "Aircraft-space-age",

--- a/mods-metadata/AbandonedRuins_updated_fork.json
+++ b/mods-metadata/AbandonedRuins_updated_fork.json
@@ -1,0 +1,6 @@
+{
+  "mod": "AbandonedRuins_updated_fork",
+  "source": "portal",
+  "upstreamVersion": "1.5.7",
+  "changeReason": "Временно ограничивает обработчик runtime-настроек настройками Ruins, чтобы изменения настроек других модов не перезапускали Ruins и не выводили отладочное сообщение"
+}

--- a/mods/AbandonedRuins_updated_fork/lua/events.lua
+++ b/mods/AbandonedRuins_updated_fork/lua/events.lua
@@ -17,13 +17,15 @@ local debug_on_tick = settings.global[constants.ENABLE_DEBUG_ON_TICK_KEY].value
 ---@type LuaEvent
 on_entity_force_changed_event = script.generate_event_name()
 
-local function update_debug_log()
+local function update_debug_log(announce)
   debug_log = settings.global[constants.ENABLE_DEBUG_LOG_KEY].value
   debug_on_tick = settings.global[constants.ENABLE_DEBUG_ON_TICK_KEY].value
-  utils.output_message(string.format("Ruins: debug log is now: debug=%s,on_tick=%s", debug_log, debug_on_tick))
+  if announce then
+    utils.output_message(string.format("Ruins: debug log is now: debug=%s,on_tick=%s", debug_log, debug_on_tick))
+  end
 end
 
-local function init()
+local function init(event)
   if debug_log then log("[init]: CALLED!") end
   if game then
     log("[init]: Initializing enemy force' cease fire ...")
@@ -42,16 +44,28 @@ local function init()
 
   -- Update debug flags
   if debug_log then log("[init]: Invoking update_debug_log() ...") end
-  update_debug_log()
+  local debug_setting_changed = event and
+    (event.setting == constants.ENABLE_DEBUG_LOG_KEY or event.setting == constants.ENABLE_DEBUG_ON_TICK_KEY)
+  update_debug_log(debug_setting_changed)
 
   if debug_log then log("[init]: EXIT!") end
+end
+
+local function on_runtime_mod_setting_changed(event)
+  local is_ruins_setting = event.setting == constants.CURRENT_RUIN_SET_KEY or
+    string.sub(event.setting, 1, 6) == "ruins-"
+  if is_ruins_setting then
+    init(event)
+  end
 end
 
 script.on_init(init)
 script.on_load(init)
 script.on_configuration_changed(init)
-script.on_event(defines.events.on_player_created, update_debug_log)
-script.on_event(defines.events.on_runtime_mod_setting_changed, init)
+script.on_event(defines.events.on_player_created, function()
+  update_debug_log(false)
+end)
+script.on_event(defines.events.on_runtime_mod_setting_changed, on_runtime_mod_setting_changed)
 
 script.on_event(defines.events.on_force_created, function()
   -- Sets up the diplomacy for all forces, not just the newly created one.


### PR DESCRIPTION
## Что видит игрок

При переключении кнопки отображения пропускной способности манипуляторов в чат выводится служебное сообщение:

`Ruins: debug log is now: debug=false,on_tick=false`

## Корень проблемы

`inserter-throughput` изменяет пользовательскую runtime-настройку, после чего Factorio отправляет `on_runtime_mod_setting_changed` всем модам. `AbandonedRuins_updated_fork` обрабатывал любое такое событие через `init()` и безусловно выводил состояние своих debug-флагов, даже когда изменилась настройка другого мода.

## Решение

- Обработчик Ruins теперь вызывает `init()` только для собственных настроек (`ruins-*` и `current-ruin-set`).
- Состояние debug-флагов выводится только при изменении соответствующих debug-настроек Ruins.
- Изменение задокументировано в `mods-metadata` как временный portal-патч версии 1.5.7.

## Почему исправление находится в стороннем моде

Исправить причину через `zzzparanoidal` невозможно: runtime-код модов выполняется в изолированных окружениях. `zzzparanoidal` не может снять обработчик `on_runtime_mod_setting_changed`, зарегистрированный Ruins, или подавить выполненный им вывод. Изменение `GUI_Unifyer` либо `inserter-throughput` только маскировало бы один сценарий, тогда как Ruins продолжал бы ошибочно реагировать на настройки остальных модов.

Поэтому внесена минимальная правка непосредственно в обработчик-владелец с декларацией отклонения от portal-версии.

## Проверка

- Синтаксис `events.lua` проверен через `luac`.
- В Factorio 2.0.77 пользователь проверил переключение inserter-throughput: функция переключается, лишнее сообщение Ruins больше не появляется.
- Проверка provenance распознаёт `AbandonedRuins_updated_fork` как документированно изменённый portal-мод; полный локальный прогон сообщает о ранее существующих рассинхронизациях lock для других project-модов.
