### PR TITLE
Синхронизирует индикатор пропускной способности манипуляторов

### DIFF
--- a/mods/zzzparanoidal/control.lua
+++ b/mods/zzzparanoidal/control.lua
@@ -1,5 +1,6 @@
 require("controls.heroturrets_script") -- скрипт разжалования турелей
 require("controls.spilled_items") -- высыпание содержимого сущности при разрушении (настройка item-drop)
+require("controls.gui-unifyer-inserter-throughput") -- синхронизация индикатора пропускной способности манипуляторов
 -- ###############################################################################################
 -- from some corpse marker
 script.on_event(defines.events.on_pre_player_died, function(event)

--- a/mods/zzzparanoidal/controls/gui-unifyer-inserter-throughput.lua
+++ b/mods/zzzparanoidal/controls/gui-unifyer-inserter-throughput.lua
@@ -1,0 +1,27 @@
+local mod_gui = require("mod-gui")
+
+if not (script.active_mods["GUI_Unifyer"] and script.active_mods["inserter-throughput"]) then
+	return
+end
+
+local function update_inserter_throughput_button(event)
+	if event.setting ~= "inserter-throughput-enabled" or not event.player_index then
+		return
+	end
+
+	local player = game.get_player(event.player_index)
+	if not player then
+		return
+	end
+
+	local button = mod_gui.get_button_flow(player)["inserter-throughput-toggle"]
+	if not (button and button.valid) then
+		return
+	end
+
+	local enabled = settings.get_player_settings(player)["inserter-throughput-enabled"].value
+	button.sprite = enabled and "inserterthroughput_on_button" or "inserterthroughput_off_button"
+	button.tooltip = enabled and {"guiu.inserterthroughput_on_button"} or {"guiu.inserterthroughput_off_button"}
+end
+
+script.on_event(defines.events.on_runtime_mod_setting_changed, update_inserter_throughput_button)


### PR DESCRIPTION
## Что видит игрок

Кнопка `inserter-throughput` меняет настройку, но индикатор `GUI_Unifyer` остаётся в прежнем состоянии: зелёная полоска и подсказка `Current: ON/OFF` не синхронизируются.

## Корень проблемы

Один клик увеличивает внутренний `checknexttick` GUI Unifyer несколько раз: по событию GUI и по последующему изменению runtime-настройки. Обновление выполняется только при точном значении `1`, поэтому при значении `2` очередь больше не обрабатывает кнопку.

## Решение

Добавляет в `zzzparanoidal` совместимый runtime-обработчик для пары `GUI_Unifyer` + `inserter-throughput`. После изменения `inserter-throughput-enabled` он синхронизирует sprite и tooltip существующей кнопки с фактическим значением настройки.

Обработчик регистрируется только при наличии обоих модов и ничего не создаёт самостоятельно.

## Почему не изменён сторонний мод

Общее исправление очереди требует изменения кода `GUI_Unifyer`, но проект старается не поддерживать локальные патчи портальных модов. Поэтому совместимость реализована в собственном слое `zzzparanoidal` без отклонения `GUI_Unifyer` от upstream-версии.

## Проверка

- Оба изменённых Lua-файла проходят синтаксическую проверку `luac`.
- Требуется итоговая проверка переключения индикатора в Factorio 2.0.77.
