### PR TITLE
Убирает скрытое исследование основ логистики AAI

### DIFF
--- a/mods/zzzparanoidal/control.lua
+++ b/mods/zzzparanoidal/control.lua
@@ -85,9 +85,22 @@ local function apply_dark_nights() -- Clockwork-2 min_brightness не трога
 	end
 end
 
+local function disable_obsolete_basic_logistics()
+	if not (script.active_mods["aai-industry"] and script.active_mods["boblogistics"]) then
+		return
+	end
+	for _, force in pairs(game.forces) do
+		local basic_logistics = force.technologies["basic-logistics"]
+		if basic_logistics and force.technologies["logistics-0"] then
+			basic_logistics.enabled = false
+		end
+	end
+end
+
 script.on_init(function() --наш любимый init, запрещаем двигать наши насосы
 	evo_and_dolly()
 	apply_dark_nights()
+	disable_obsolete_basic_logistics()
 end)
 
 script.on_load(function() --без дропа эволюции потому что game недоступен
@@ -112,6 +125,8 @@ script.on_configuration_changed(function(data) --фикс эволюции пр�
 		end
 	end
 	apply_dark_nights()
+	disable_obsolete_basic_logistics()
 end)
 
 script.on_event(defines.events.on_surface_created, apply_dark_nights)
+script.on_event(defines.events.on_player_joined_game, disable_obsolete_basic_logistics)

--- a/mods/zzzparanoidal/data-final-fixes.lua
+++ b/mods/zzzparanoidal/data-final-fixes.lua
@@ -68,6 +68,7 @@ require("tweaks.custom.selections")
 require("removals.bio-modules")
 require("removals.fishes")
 require("removals.aai-medium-electric-pole")
+require("removals.aai-basic-logistics")
 require("removals.clowns-steel-c2")
 require("removals.angels-valves") -- прячем Angels-flow-клапаны: заменены модом valves (inspector остаётся)
 

--- a/mods/zzzparanoidal/removals/aai-basic-logistics.lua
+++ b/mods/zzzparanoidal/removals/aai-basic-logistics.lua
@@ -1,0 +1,7 @@
+require("__zzzparanoidal__.paralib")
+
+local basic_logistics = data.raw.technology["basic-logistics"]
+if basic_logistics and basic_logistics.hidden and data.raw.technology["logistics-0"] then
+	-- AAI повторно включает уже скрытую Bob Logistics технологию с активным research_trigger.
+	paralib.bobmods.lib.tech.hide("basic-logistics")
+end


### PR DESCRIPTION
## Что видит игрок

В верхней панели самопроизвольно появляется исследование «Основы логистики 2». Оно прогрессирует от изготовления двигателей, но отсутствует в поиске дерева технологий и ничего не открывает.

## Корень проблемы

Итоговый прототип `basic-logistics` одновременно имеет:

- `hidden = true`;
- `enabled = true`;
- пустой список эффектов;
- `research_trigger` на изготовление 50 `motor`.

AAI Industry создаёт эту технологию. При наличии `logistics-0` Bob Logistics скрывает и отключает её как заменённую, удаляет рецепты и зависимости. Затем `aai-industry/data-final-fixes.lua` снова устанавливает `enabled = true`, а runtime-обработчик AAI повторяет это для существующих forces. В результате скрытый пустой прототип продолжает автоматически исследоваться.

## Решение

- На `data-final-fixes` повторно скрывает и отключает `basic-logistics`, только если она уже скрыта и существует замена `logistics-0`.
- На runtime отключает технологию после инициализации и configuration change AAI, включая существующие сохранения.
- При входе игрока повторяет безопасную синхронизацию, чтобы локальные изменения кода применялись без сброса сохранения.

Правка находится в `zzzparanoidal`; исходники AAI Industry и Bob Logistics не изменяются.

## Проверка

- Пользователь проверил исправление в Factorio 2.0.77: скрытое исследование исчезло.
- Изолированный `--dump-data` успешно завершён.
- Итоговый `basic-logistics`: `hidden=true`, `enabled=false`, `effects={}`.
- Изменённые Lua-файлы проходят `luac`, `git diff --check` не сообщает ошибок.
