### PR TITLE
Перестраивает раннюю энергетическую прогрессию

### DIFF
--- a/mods/zzzparanoidal/data-final-fixes.lua
+++ b/mods/zzzparanoidal/data-final-fixes.lua
@@ -95,6 +95,7 @@ require("tweaks.custom.uniform-recipies")
 angelsmods.functions.OV.execute()
 
 require("tweaks.technology.clowns-processing") -- Clowns-Processing: актуальный prerequisite Bob's tungsten
+require("tweaks.technology.energy-balance") -- ранняя энергетика без обработанного топлива и отдельной электрификации
 
 -- molten-*-alloy-mixing/remelting не имеют recipe-name локали → "Unknown key" в 2.0
 -- (icons-оверлей ломает авто-вывод). Берём имя из fluid-результата.

--- a/mods/zzzparanoidal/final-fixes/technologies.lua
+++ b/mods/zzzparanoidal/final-fixes/technologies.lua
@@ -95,13 +95,6 @@ paralib.bobmods.lib.tech.add_recipe_unlock("angels-basic-chemistry-2", "angels-c
 --целюлозное волокно в переработку древесины
 paralib.bobmods.lib.tech.add_recipe_unlock("angels-bio-wood-processing", "angels-cellulose-fiber-raw-wood")
 -------------------------------------------------------------------------------------------------
---конденсатор в электричество
--- bob-electricity есть только при burner-phase (bobmods-burnerphase); с aai-industry он выключен
--- → техи нет, анлок молча отваливается. Фолбэк на ванильную electricity (тот же ранний тир).
-local elec = data.raw.technology["bob-electricity"] and "bob-electricity" or "electricity"
-paralib.bobmods.lib.recipe.enabled("condensator", false)
-paralib.bobmods.lib.tech.add_recipe_unlock(elec, "condensator")
--------------------------------------------------------------------------------------------------
 --паровой манипулятор в автоматику
 paralib.bobmods.lib.recipe.enabled("bob-steam-inserter", false)
 -------------------------------------------------------------------------------------------------

--- a/mods/zzzparanoidal/settings-final-fixes.lua
+++ b/mods/zzzparanoidal/settings-final-fixes.lua
@@ -145,6 +145,13 @@ end
 -- startup влияют на прототипы(сущности, предметы, рецепты, технологии и их связи между собой)
 if mods["aai-industry"] then
     set_settings_default_value("int-setting", "aai-burner-turbine-efficiency", 25)
+
+    local fuel_processor = data.raw["bool-setting"]["aai-fuel-processor"]
+    if fuel_processor then
+        fuel_processor.default_value = false
+        fuel_processor.hidden = true
+        fuel_processor.forced_value = false
+    end
 end
 if mods["Aircraft-space-age"] then
     set_settings_default_value("bool-setting", "aircraft-hardmode", true)

--- a/mods/zzzparanoidal/tweaks/technology/energy-balance.lua
+++ b/mods/zzzparanoidal/tweaks/technology/energy-balance.lua
@@ -1,0 +1,54 @@
+require("__zzzparanoidal__.paralib")
+
+local function remove_recipe_unlock(recipe_name)
+    for _, technology in pairs(data.raw.technology) do
+        if technology.effects then
+            for index = #technology.effects, 1, -1 do
+                local effect = technology.effects[index]
+                if effect.type == "unlock-recipe" and effect.recipe == recipe_name then
+                    table.remove(technology.effects, index)
+                end
+            end
+        end
+    end
+end
+
+local function remove_prerequisite(prerequisite_name)
+    for _, technology in pairs(data.raw.technology) do
+        if technology.prerequisites then
+            for index = #technology.prerequisites, 1, -1 do
+                if technology.prerequisites[index] == prerequisite_name then
+                    table.remove(technology.prerequisites, index)
+                end
+            end
+        end
+    end
+end
+
+-- Убираем отдельную ступень электрификации Bob's, не заменяя её другой зависимостью.
+local electricity = data.raw.technology["bob-electricity"]
+if electricity then
+    remove_prerequisite("bob-electricity")
+    electricity.enabled = false
+    electricity.hidden = true
+    electricity.effects = {}
+end
+
+-- Железоугольный аккумулятор идёт после основ электрификации AAI.
+if data.raw.technology["fe-c-accumulator"] and data.raw.technology["electricity"] then
+    paralib.bobmods.lib.tech.add_prerequisite("fe-c-accumulator", "electricity")
+end
+
+-- Конденсаторы открываются электроникой.
+if data.raw.recipe["condensator"] and data.raw.technology["electronics"] then
+    remove_recipe_unlock("condensator")
+    paralib.bobmods.lib.recipe.enabled("condensator", false)
+    paralib.bobmods.lib.tech.add_recipe_unlock("electronics", "condensator")
+end
+
+-- Малый столб с лампой открывается только исследованием фонаря.
+if data.raw.recipe["lighted-small-electric-pole"] and data.raw.technology["lamp"] then
+    remove_recipe_unlock("lighted-small-electric-pole")
+    paralib.bobmods.lib.recipe.enabled("lighted-small-electric-pole", false)
+    paralib.bobmods.lib.tech.add_recipe_unlock("lamp", "lighted-small-electric-pole")
+end


### PR DESCRIPTION
## Что видит игрок

- Исследование и постройка переработчика топлива AAI дают бесплатный прирост энергии и чрезмерные транспортные бонусы.
- В раннем дереве одновременно присутствуют «Электрификация» Bob's и «Основы электрификации» AAI.
- Конденсаторы и малый столб с лампой открываются не в тематических исследованиях.
- Исследование железоугольного аккумулятора стоит отдельно от энергетической ветки.

## Корень проблемы

AAI Industry включает переработку топлива стартовой настройкой. Дополнительно разные моды добавляют зависимости и открытия рецептов в обе ранние электрические технологии, из-за чего в итоговом дереве появляется дублирующая ступень и повторные открытия.

## Решение

- Принудительно выключает и скрывает настройку переработчика топлива AAI.
- Скрывает `bob-electricity` и удаляет ссылки на неё без подстановки другой зависимости.
- Оставляет `condensator` только в `electronics`.
- Оставляет `lighted-small-electric-pole` только в `lamp`.
- Добавляет `electricity` как prerequisite для `fe-c-accumulator`.
- Не изменяет обычный малый электрический столб.

## Проверка

- `luac -p` для измененных Lua-файлов — успешно.
- `git diff --check` — успешно.
- `--dump-data` в Factorio 2.0.77 — успешно.
- По дампу: переработчик и обработанное топливо скрыты; `bob-electricity` скрыта; ссылок на неё в prerequisites нет; конденсатор открывается только электроникой; малый столб с лампой — только фонарём; железоугольный аккумулятор зависит от основ электрификации.

Требуется итоговая проверка дерева технологий в игре.
