### PR TITLE
Возвращает замедление загруженных поездов

### DIFF
--- a/mods-metadata/!expected.json
+++ b/mods-metadata/!expected.json
@@ -326,6 +326,12 @@
       "metadataHash": null
     },
     {
+      "name": "OverloadedTrainsSimple",
+      "version": "0.1.0",
+      "contentHash": null,
+      "metadataHash": "6abcd397b00637f6d8042e588e9f4f4a0869f774a225a5074964d9c89c06ab05"
+    },
+    {
       "name": "PCPRedux",
       "version": "1.1.0",
       "contentHash": "44274ab9d3bdea349a31b3342ada2753",

--- a/mods-metadata/OverloadedTrainsSimple.json
+++ b/mods-metadata/OverloadedTrainsSimple.json
@@ -1,0 +1,13 @@
+{
+  "mod": "OverloadedTrainsSimple",
+  "source": "local",
+  "original": {
+    "name": "Overloaded Trains",
+    "authors": ["OwnlyMe"],
+    "portal": {
+      "name": "OverloadedTrains",
+      "url": "https://mods.factorio.com/mod/OverloadedTrains"
+    }
+  },
+  "changeReason": "Локальный форк SEO-master, не публикуемый на Mod Portal. Упрощённая безопасная замена механики Beta 8: ускорение зависит от занятых ячеек и объёма жидкости без уничтожения и пересоздания вагонов."
+}

--- a/mods/OverloadedTrainsSimple/control.lua
+++ b/mods/OverloadedTrainsSimple/control.lua
@@ -1,0 +1,167 @@
+local TRAINS_PER_TICK = 6
+local LOAD_REFRESH_INTERVAL = 60
+
+local function ensure_state()
+  storage.overloaded_trains_simple = storage.overloaded_trains_simple or {
+    trains = {},
+    cursor = nil,
+  }
+  return storage.overloaded_trains_simple
+end
+
+local function calculate_load(train)
+  local occupied_slots = 0
+  local fluid_amount = 0
+
+  for _, wagon in pairs(train.cargo_wagons) do
+    local inventory = wagon.get_inventory(defines.inventory.cargo_wagon)
+    if inventory then
+      for slot = 1, #inventory do
+        if inventory[slot].valid_for_read then
+          occupied_slots = occupied_slots + 1
+        end
+      end
+    end
+  end
+
+  for _, amount in pairs(train.get_fluid_contents()) do
+    fluid_amount = fluid_amount + amount
+  end
+
+  return occupied_slots, fluid_amount
+end
+
+local function register_train(train)
+  if not (train and train.valid) then
+    return
+  end
+
+  local state = ensure_state()
+  local occupied_slots, fluid_amount = calculate_load(train)
+  local entry = state.trains[train.id]
+  if entry then
+    entry.train = train
+    entry.occupied_slots = occupied_slots
+    entry.fluid_amount = fluid_amount
+    entry.load_tick = game.tick
+    entry.speed = train.speed
+  else
+    state.trains[train.id] = {
+      train = train,
+      occupied_slots = occupied_slots,
+      fluid_amount = fluid_amount,
+      load_tick = game.tick,
+      speed = train.speed,
+    }
+  end
+end
+
+local function remove_train(id)
+  if not id then
+    return
+  end
+
+  local state = ensure_state()
+  state.trains[id] = nil
+  if state.cursor == id then
+    state.cursor = nil
+  end
+end
+
+local function rebuild_trains()
+  storage.overloaded_trains_simple = {
+    trains = {},
+    cursor = nil,
+  }
+
+  for _, train in pairs(game.train_manager.get_trains({})) do
+    register_train(train)
+  end
+end
+
+local function discover_trains()
+  local state = ensure_state()
+  for _, train in pairs(game.train_manager.get_trains({})) do
+    if not state.trains[train.id] then
+      register_train(train)
+    end
+  end
+end
+
+local function on_train_created(event)
+  remove_train(event.old_train_id_1)
+  remove_train(event.old_train_id_2)
+  register_train(event.train)
+end
+
+local function on_train_changed_state(event)
+  register_train(event.train)
+end
+
+local function next_train(state)
+  local id = next(state.trains, state.cursor)
+  if not id then
+    id = next(state.trains)
+  end
+  state.cursor = id
+  return id, id and state.trains[id] or nil
+end
+
+local function slow_acceleration(entry)
+  local train = entry.train
+  if not (train and train.valid) then
+    return false
+  end
+
+  if entry.occupied_slots == nil or entry.fluid_amount == nil or game.tick - entry.load_tick >= LOAD_REFRESH_INTERVAL then
+    entry.occupied_slots, entry.fluid_amount = calculate_load(train)
+    entry.load_tick = game.tick
+  end
+
+  local current_speed = train.speed
+  local previous_speed = entry.speed or current_speed
+  local current_absolute = math.abs(current_speed)
+  local previous_absolute = math.abs(previous_speed)
+
+  if current_speed ~= 0
+    and previous_speed * current_speed >= 0
+    and current_absolute > previous_absolute
+    and (entry.occupied_slots > 0 or entry.fluid_amount > 0)
+  then
+    local slots_for_minimum = settings.global["ots-slots-for-minimum-acceleration"].value
+    local fluid_for_minimum = settings.global["ots-fluid-for-minimum-acceleration"].value
+    local minimum_acceleration = settings.global["ots-minimum-acceleration"].value
+    local load_fraction = entry.occupied_slots / slots_for_minimum + entry.fluid_amount / fluid_for_minimum
+    local acceleration_factor = 1 - math.min(load_fraction, 1) * (1 - minimum_acceleration)
+    local adjusted_absolute = previous_absolute + (current_absolute - previous_absolute) * acceleration_factor
+    train.speed = current_speed < 0 and -adjusted_absolute or adjusted_absolute
+    current_speed = train.speed
+  end
+
+  entry.speed = current_speed
+  return true
+end
+
+local function on_tick()
+  local state = ensure_state()
+  local visited = {}
+
+  for _ = 1, TRAINS_PER_TICK do
+    local id, entry = next_train(state)
+    if not id or visited[id] then
+      break
+    end
+    visited[id] = true
+
+    if not slow_acceleration(entry) then
+      remove_train(id)
+    end
+  end
+end
+
+script.on_init(rebuild_trains)
+script.on_configuration_changed(rebuild_trains)
+script.on_event(defines.events.on_train_created, on_train_created)
+script.on_event(defines.events.on_train_changed_state, on_train_changed_state)
+script.on_event(defines.events.on_tick, on_tick)
+script.on_nth_tick(60, discover_trains)

--- a/mods/OverloadedTrainsSimple/control.lua
+++ b/mods/OverloadedTrainsSimple/control.lua
@@ -16,11 +16,7 @@ local function calculate_load(train)
   for _, wagon in pairs(train.cargo_wagons) do
     local inventory = wagon.get_inventory(defines.inventory.cargo_wagon)
     if inventory then
-      for slot = 1, #inventory do
-        if inventory[slot].valid_for_read then
-          occupied_slots = occupied_slots + 1
-        end
-      end
+      occupied_slots = occupied_slots + (#inventory - inventory.count_empty_stacks())
     end
   end
 

--- a/mods/OverloadedTrainsSimple/info.json
+++ b/mods/OverloadedTrainsSimple/info.json
@@ -1,0 +1,13 @@
+{
+  "name": "OverloadedTrainsSimple",
+  "version": "0.1.0",
+  "title": "Overloaded Trains Simple (Paranoidal Fork)",
+  "author": "SEO-master",
+  "factorio_version": "2.0",
+  "description": "Local Paranoidal fork. Progressively reduces train acceleration according to occupied cargo-wagon slots and carried fluid without replacing rolling stock. This fork is not published on the Mod Portal.",
+  "dependencies": [
+    "base >= 2.0.77",
+    "! space-age",
+    "! quality"
+  ]
+}

--- a/mods/OverloadedTrainsSimple/locale/en/locale.cfg
+++ b/mods/OverloadedTrainsSimple/locale/en/locale.cfg
@@ -1,0 +1,9 @@
+[mod-setting-name]
+ots-slots-for-minimum-acceleration=Occupied slots for minimum acceleration
+ots-fluid-for-minimum-acceleration=Fluid amount for minimum acceleration
+ots-minimum-acceleration=Minimum acceleration
+
+[mod-setting-description]
+ots-slots-for-minimum-acceleration=Number of occupied cargo-wagon slots that alone reaches the minimum acceleration multiplier.
+ots-fluid-for-minimum-acceleration=Total carried fluid amount that alone reaches the minimum acceleration multiplier.
+ots-minimum-acceleration=Lowest positive acceleration multiplier. Item-slot and fluid contributions are added together; empty trains retain normal acceleration.

--- a/mods/OverloadedTrainsSimple/locale/ru/locale.cfg
+++ b/mods/OverloadedTrainsSimple/locale/ru/locale.cfg
@@ -1,0 +1,9 @@
+[mod-setting-name]
+ots-slots-for-minimum-acceleration=Занятых ячеек для минимального разгона
+ots-fluid-for-minimum-acceleration=Объём жидкости для минимального разгона
+ots-minimum-acceleration=Минимальный разгон
+
+[mod-setting-description]
+ots-slots-for-minimum-acceleration=Количество занятых ячеек грузовых вагонов, которое само по себе даёт минимальный множитель разгона.
+ots-fluid-for-minimum-acceleration=Общий объём перевозимой жидкости, который сам по себе даёт минимальный множитель разгона.
+ots-minimum-acceleration=Минимальный множитель положительного ускорения. Вклад занятых ячеек и жидкости суммируется; пустые поезда разгоняются как обычно.

--- a/mods/OverloadedTrainsSimple/settings.lua
+++ b/mods/OverloadedTrainsSimple/settings.lua
@@ -1,0 +1,29 @@
+data:extend({
+  {
+    type = "int-setting",
+    name = "ots-slots-for-minimum-acceleration",
+    setting_type = "runtime-global",
+    default_value = 80,
+    minimum_value = 1,
+    maximum_value = 10000,
+    order = "a",
+  },
+  {
+    type = "int-setting",
+    name = "ots-fluid-for-minimum-acceleration",
+    setting_type = "runtime-global",
+    default_value = 200000,
+    minimum_value = 1,
+    maximum_value = 1000000000,
+    order = "b",
+  },
+  {
+    type = "double-setting",
+    name = "ots-minimum-acceleration",
+    setting_type = "runtime-global",
+    default_value = 0.1,
+    minimum_value = 0.01,
+    maximum_value = 1,
+    order = "c",
+  },
+})


### PR DESCRIPTION
Возвращает механику замедления загруженных поездов из Beta 8 без подмены вагонов.

- Ускорение линейно снижается до 0,1 при 80 занятых ячейках или 200 000 жидкости; вклады суммируются.
- Торможение и максимальная скорость не меняются.
- Локальный форк SEO-master, на Mod Portal не публикуется.

Проверено на Factorio 2.0.77: изолированные runtime-тесты груза и жидкости, запуск полного модсета без Creative Mod.
