### PR TITLE
Исправляет модернизацию рельсов Junk Train без изменения base

### DIFF
--- a/mods/JunkTrain3/locale/en/locale.cfg
+++ b/mods/JunkTrain3/locale/en/locale.cfg
@@ -29,7 +29,7 @@ rail-chain-signal-scrap=Primitive rail chain signal
 [entity-description]
 yir_usl=A cheap, low-powered locomotive of simplified construction.
 yir_us_cargo=A small, cheap freight wagon of simplified construction.
-scrap-rail=Fragile rails with wooden sleepers.\nAccumulate 1 damage per km/h above 80 under a passing train.
+scrap-rail=Fragile rails with wooden sleepers.\nAccumulate 1 damage per km/h above 80 under a passing train. Damage is applied after the rail segment is freed.
 train-stop-scrap=A primitive train stop for early rail automation.
 rail-signal-scrap=A primitive rail signal for early rail automation.
 rail-chain-signal-scrap=A primitive chain signal for early rail automation.

--- a/mods/JunkTrain3/prototypes/rails.lua
+++ b/mods/JunkTrain3/prototypes/rails.lua
@@ -67,8 +67,6 @@ end
 local rails = {}
 for _, definition in ipairs(rail_definitions) do
   local target = data.raw[definition.type][definition.source]
-  target.fast_replaceable_group = "rail"
-
   local rail = table.deepcopy(target)
   rail.name = definition.name
   rail.localised_name = {"entity-name.scrap-rail"}
@@ -83,7 +81,11 @@ for _, definition in ipairs(rail_definitions) do
   rail.max_health = definition.health
   rail.resistances = nil
   rail.next_upgrade = definition.source
-  rail.fast_replaceable_group = "rail"
+  -- Factorio assigns ungrouped rails their prototype name during setup.
+  rail.fast_replaceable_group = target.fast_replaceable_group
+  if not rail.fast_replaceable_group or rail.fast_replaceable_group == "" then
+    rail.fast_replaceable_group = target.name
+  end
   rail.factoriopedia_alternative = "straight-scrap-rail"
   apply_primitive_palette(rail.pictures)
   rails[#rails + 1] = rail


### PR DESCRIPTION
## Что исправляет

Завершает два замечания ревью уже влитого PR #355:

- JunkTrain3 больше не меняет `fast_replaceable_group` четырёх исходных рельсов base. Примитивная копия получает непустую группу цели либо имя целевого прототипа, сохраняя штатную модернизацию.
- EN-подсказка сущности теперь, как уже исправленная подсказка предмета, сообщает, что накопленный урон наносится после освобождения рельса. Формулировка принятого коммита `03973d526` сохранена.

## Причина

Присваивание `target.fast_replaceable_group = "rail"` меняло исходные прототипы в `data.raw` до копирования. Просто удалить его и наследовать nil нельзя: Factorio 2.0.77 при setup назначает негруппированным рельсам их собственные имена, и при разных именах исходного и примитивного рельса загрузка прерывается проверкой `next_upgrade`. Поэтому fallback применяется только к примитивной копии и равен имени цели.

Это исправление добавленной при порте реализации, не изменение баланса Beta 8. Рецепты, стоимость, здоровье, геометрия, механика износа и runtime-код не меняются. Прототипы не удаляются и не переименовываются. Metadata и `!expected.json` не менялись.

## Проверки

Factorio 2.0.77, независимые профили, рабочие сейвы/настройки не использовались для записи:

- минимальный data-stage: рекурсивное сравнение всех четырёх исходных base-прототипов до/после загрузки production `rails.lua` — без изменений;
- минимальный и полный модсет: `next_upgrade`, совпадение групп, `order_upgrade` и `get_upgrade_target` — 4/4;
- в физической копии полного модсета настоящие строительные роботы заменили прямой, полудиагональный и оба изогнутых примитивных рельса на соответствующие base-рельсы — 4/4;
- проверенный `rails.lua` побайтно совпадает с публикуемым; обе EN-подсказки согласованы;
- `git diff --check` прошёл, SHA-256 рабочих `mod-list.json` и `mod-settings.dat` не изменились.

Задания роботам даны через API `order_upgrade`, не кликом GUI-планировщика. `--benchmark` использован только для исполнения 3601 runtime-тика, не для измерения производительности. GUI-планировщик/подсказки и миграция старого сейва не проверены.

Треды исходного ревью: [группы рельсов](https://github.com/FactorioParanoidal/ParanoidalModpack/pull/355#discussion_r3989211241), [EN-подсказка](https://github.com/FactorioParanoidal/ParanoidalModpack/pull/355#discussion_r3990886077).
