### PR TITLE
Переносит выбранные дефолты настроек Beta 8 в zzzparanoidal

### DIFF
--- a/mods/zzzparanoidal/settings-final-fixes.lua
+++ b/mods/zzzparanoidal/settings-final-fixes.lua
@@ -218,7 +218,11 @@ if mods["bobmodules"] then
         "bobmods-modules-start-bonus-pollution",
         "bobmods-modules-start-bonus-pollutioncreate",
     }) do
-        data.raw["double-setting"][name].minimum_value = 0
+        local setting = data.raw["double-setting"] and data.raw["double-setting"][name]
+        if not setting then
+            error("mod setting data.raw['double-setting']['" .. name .. "'] not exists!")
+        end
+        setting.minimum_value = 0
         set_settings_default_value("double-setting", name, 0)
     end
 

--- a/mods/zzzparanoidal/settings-final-fixes.lua
+++ b/mods/zzzparanoidal/settings-final-fixes.lua
@@ -128,6 +128,7 @@ end
 -- end runtime.global
 -- runtime.per_user влияют на каждого игрока в отдельности
 if mods["PMRPGsystem"] then
+    set_settings_default_value("bool-setting", "charxpmod_print_xp_user", true)
     set_settings_default_value("bool-setting", "charxpmod_hide_xp_panel", true)
 end
 if mods["PipeVisualizer-Updated"] then
@@ -195,6 +196,7 @@ if mods["bobores"] then
     set_settings_default_value("double-setting", "bobmods-gems-topazratio", 0.15)
 end
 if mods["boblogistics"] then
+    set_settings_default_value("int-setting", "bobmods-logistics-fluidwagonbase", 25)
     set_settings_default_value("bool-setting", "bobmods-logistics-beltoverhaulspeed", true)
     set_settings_default_value("int-setting", "bobmods-logistics-beltperlevel", 6)
     set_settings_default_value("double-setting", "bobmods-logistics-beltspeedperlevel", 12.5)
@@ -207,6 +209,26 @@ if mods["bobmining"] then
 end
 if mods["bobmodules"] then
     set_settings_default_value("bool-setting", "bobmods-modules-enablegodmodules", true)
+
+    -- Beta 8 defaults; Bob 2.1 raised these five lower bounds to 0.01.
+    for _, name in ipairs({
+        "bobmods-modules-start-bonus-speed",
+        "bobmods-modules-start-bonus-productivity",
+        "bobmods-modules-start-bonus-consumption",
+        "bobmods-modules-start-bonus-pollution",
+        "bobmods-modules-start-bonus-pollutioncreate",
+    }) do
+        data.raw["double-setting"][name].minimum_value = 0
+        set_settings_default_value("double-setting", name, 0)
+    end
+
+    set_settings_default_value("double-setting", "bobmods-modules-perlevel-bonus-speed", 0.20)
+    set_settings_default_value("double-setting", "bobmods-modules-perlevel-bonus-productivity", 0.05)
+    set_settings_default_value("double-setting", "bobmods-modules-perlevel-bonus-pollution", 0.15)
+    set_settings_default_value("double-setting", "bobmods-modules-perlevel-penalty-pollution", 0.15)
+    set_settings_default_value("double-setting", "bobmods-modules-start-penalty-speed", 0.20)
+    set_settings_default_value("double-setting", "bobmods-modules-start-penalty-consumption", 0)
+    set_settings_default_value("double-setting", "bobmods-modules-start-penalty-pollution", 0)
 end
 if mods["bobplates"] then
     set_settings_default_value("bool-setting", "bobmods-plates-bluedeuterium", true)


### PR DESCRIPTION
## Причина и результаты аудита

Проведён аудит системы настроек пользовательской Paranoidal Beta 8 и текущего порта на Factorio 2.0. Сравнение предоставленных профилей и итоговых определений выявило **55 различий значений среди настроек с совпадающими ID и областью действия**. Всего рассмотрено 1183 определения Beta 8 и 1055 определений 2.0; настройки только одной версии не включены в число 55.

После ручного ревью принято перенести **14 выбранных значений**. Оставшиеся 41 различие по решению пользователя признаны несущественными для геймплея в рамках этого переноса и оставлены без изменений. Это решение ручного ревью, а не утверждение об автоматическом доказательстве эквивалентности всех подсистем.

## Изменения

Дефолты сборки задаются в существующих блоках `zzzparanoidal/settings-final-fixes.lua`, штатным helper. `zzzparanoidal-settings` остаётся отдельным каркасом для будущего скрытия и в этом PR не меняется.

| Настройка | Дефолт Beta 8 |
|---|---:|
| `charxpmod_print_xp_user` | `true` |
| `bobmods-logistics-fluidwagonbase` | `25` |
| `bobmods-modules-perlevel-bonus-speed` | `0.20` |
| `bobmods-modules-perlevel-bonus-productivity` | `0.05` |
| `bobmods-modules-perlevel-bonus-pollution` | `0.15` |
| `bobmods-modules-perlevel-penalty-pollution` | `0.15` |
| `bobmods-modules-start-bonus-speed` | `0` |
| `bobmods-modules-start-bonus-productivity` | `0` |
| `bobmods-modules-start-bonus-consumption` | `0` |
| `bobmods-modules-start-bonus-pollution` | `0` |
| `bobmods-modules-start-bonus-pollutioncreate` | `0` |
| `bobmods-modules-start-penalty-speed` | `0.20` |
| `bobmods-modules-start-penalty-consumption` | `0` |
| `bobmods-modules-start-penalty-pollution` | `0` |

У пяти нулевых стартовых бонусов Bob минимальная граница возвращена с `0.01` до `0`, иначе запрошенные дефолты невалидны. RPG-настройка относится к `runtime-per-user`, остальные 13 — к `startup`. Исходный дефолт RPG уже равен `true`; явное переопределение закрепляет его в слое сборки, а не меняет сохранённое `false`.

## Безопасность применения

- Меняются дефолты для отсутствующих сохранённых значений, без `forced_value` и скрытия.
- Существующие `mod-settings.dat` и настройки игроков не сбрасываются; новая карта сама по себе не означает чистый профиль.
- Рабочие настройки, списки модов, сейвы и исходная Beta 8 не изменялись.
- Переносятся выбранные параметры, а не все формулы и механики модулей Beta 8.

## Проверки

- Factorio **2.0.77**: три изолированных запуска `--dump-data` (чистые профили с переопределениями/без них, копия существующего профиля).
- Полный модсет: два запуска до переноса логики в основной zzz и два после; по 188 загруженных модов с тестовым наблюдателем, без Creative и DLC.
- Чистый профиль получает целевые значения; копия существующего профиля сохраняет прежние startup и личную настройку XP.
- Целевые схемы, startup-значения и SHA-256 полных дампов до/после перемещения логики в zzzparanoidal совпали.
- В изолированном сравнении изменились только 5 жидкостных вагонов и 25 модулей; вместимости вагонов составляют 25 000 / 37 500 / 50 000.
- Пользователь проверил все 14 значений в GUI тестового профиля: «все совпало». Проверка была до перемещения логики; после перемещения повторены технические проверки.
- Контрольные хеши исходных настроек/списков совпали; `git diff --check` пройден.

`--dump-data` не выполняет `control.lua`: поведение сообщений XP в runtime и загрузка существующего сейва этим PR отдельно не проверены.
